### PR TITLE
Portable self-update: in-place swap with journaled recovery

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,6 +32,7 @@ network code.
 |  Hauling(HaulTracker/Parser/Contract/Shard) |             |
 |  Network(File/Store/Scope) |                              |
 |  Update(Service/Verifier/Manifest/Notice) |               |
+|  PortableUpdater / SwapJournal (portable self-update) |   |
 |  Diagnostics(CrashGuard/Breadcrumbs/Sanitizer/Notice) |   |
 |  Logger / InteractionLog / ForegroundMonitor              |
 +----------------------------+------------------------------+
@@ -96,6 +97,13 @@ The view model controls these services. Each service holds little or no state.
   only code in the app that touches the network, and only `UpdateService` (with
   its HTTP transport) does. The other three do no network work: signature and
   hash verification, manifest parsing, and the notice text.
+- **PortableUpdater / SwapJournal** - the portable self-update (see Key flows).
+  PortableUpdater verifies the download again on one open file handle, unpacks
+  it, and verifies each file. It then replaces the app's files with journaled
+  renames. It rolls the renames back if a step fails while the app is open.
+  SwapJournal is the write-ahead record of each rename. NexusApp reads
+  SwapJournal at the next start. It removes the `.old` files after a complete
+  swap. It puts the previous version back after an incomplete one.
 - **Logger / InteractionLog / ForegroundMonitor / DiagnosticSnapshot** - the
   diagnostics. These are a self-rotating event log, UI-interaction breadcrumbs,
   tracking of the foreground window and process, and the copy/save diagnostic
@@ -136,7 +144,9 @@ types.
   pinned public key, the hash checks, and the strictly-greater version rule. It
   gates `UpdateService`. The update subsystem is the only code in the app that
   touches the network. Downloads land in `%AppData%\NexusApp\updates`. NexusApp
-  checks their hash before the installer ever runs.
+  checks their hash before the installer ever runs. The installer flavor runs the
+  verified installer file. The portable flavor can install the update itself,
+  without a helper program and without a script. See Portable self-update below.
 
 ## Key flows
 
@@ -186,6 +196,35 @@ shares the file out-of-band, for example on Discord or a drive. When the user
 imports files from other people, NexusApp builds a roster. `NetworkScope` creates
 coverage views (who owns what, gaps, and single-owner risk). `NetworkScope` can
 filter all of NexusApp to a single member. No server is involved.
+
+### Portable self-update
+The portable flavor of NexusApp can install an update itself. NexusApp does the
+whole update while it is open. Then it restarts as the new version. No helper
+program runs, and no script runs. The signed manifest format does not change.
+
+1. NexusApp verifies the downloaded file against the signed manifest.
+2. NexusApp opens that file one time and verifies it again on the open handle.
+   So the bytes that NexusApp checks are the bytes that NexusApp unpacks.
+3. NexusApp unpacks the file and keeps the hash of each unpacked file.
+4. NexusApp copies the unpacked files into its own folder as a staged set.
+5. NexusApp then does one file at a time. It verifies the staged copy again. It
+   renames the current file to a `.old` name. It renames the staged file into
+   place. `NexusApp.exe` is always the last file.
+6. NexusApp restarts. The old process starts the new process as its last action.
+7. The next start removes the `.old` files and the download.
+
+A journal records each rename before that rename happens. NexusApp writes the
+journal to the per-user app-data folder, not to the install folder. If the
+update stops part way, the next start reads the journal and puts the previous
+version back from the `.old` files. NexusApp keeps the verified download until
+the new version starts one time. NexusApp treats the journal as untrusted input
+when it reads the journal back.
+
+NexusApp tries the self-update only when the conditions are safe. NexusApp does
+not try it in a protected folder, on a network drive, or with a second NexusApp
+window open. NexusApp then offers a manual update. When the user chooses it,
+NexusApp verifies and unpacks the update and opens the new folder and the
+current folder. The user then does one copy.
 
 ## Build, test, and CI
 

--- a/NexusApp.Tests/PortableUpdaterTests.cs
+++ b/NexusApp.Tests/PortableUpdaterTests.cs
@@ -153,4 +153,110 @@ public class PortableUpdaterTests : IDisposable
     [InlineData("")]
     public void NormalizeEntry_Rejects(string entry) =>
         Assert.NotNull(PortableUpdater.NormalizeEntry(entry, out _));
+
+    // ---- VerifyAndExtract (same-handle verify, hardened extraction) ----
+
+    private static string HashHex(byte[] data) =>
+        Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(data)).ToLowerInvariant();
+
+    // Builds a zip at a temp path from (entryName, content) pairs and returns (path, hash).
+    private (string path, string sha256) MakeZip(params (string name, string content)[] entries)
+    {
+        var path = Path.Combine(TempDir(), "payload.zip");
+        using (var fs = File.Create(path))
+        using (var zip = new System.IO.Compression.ZipArchive(fs, System.IO.Compression.ZipArchiveMode.Create))
+            foreach (var (name, content) in entries)
+            {
+                var e = zip.CreateEntry(name);
+                using var s = e.Open();
+                var bytes = System.Text.Encoding.UTF8.GetBytes(content);
+                s.Write(bytes, 0, bytes.Length);
+            }
+        return (path, HashHex(File.ReadAllBytes(path)));
+    }
+
+    private static (string name, string content)[] GoodEntries() => new[]
+    {
+        ("NexusApp/NexusApp.exe", "new exe bytes"),
+        ("NexusApp/e_sqlite3.dll", "new sqlite bytes"),
+        ("NexusApp/wpfgfx_cor3.dll", "new wpf bytes"),
+        ("NexusApp/README.txt", "new readme"),
+        ("NexusApp/Web/cargo/index.html", "new page"),
+    };
+
+    [Fact]
+    public void VerifyAndExtract_HappyPath_ExtractsAndHashes()
+    {
+        var (zip, hash) = MakeZip(GoodEntries());
+        var dest = Path.Combine(TempDir(), "staged", "NexusApp");
+        var result = PortableUpdater.VerifyAndExtract(zip, hash, dest);
+        Assert.Equal("new exe bytes", File.ReadAllText(Path.Combine(dest, "NexusApp.exe")));
+        Assert.Equal("new page", File.ReadAllText(Path.Combine(dest, "Web", "cargo", "index.html")));
+        Assert.Equal(5, result.FileHashes.Count);
+        Assert.Equal(HashHex(System.Text.Encoding.UTF8.GetBytes("new page")), result.FileHashes[@"Web\cargo\index.html"]);
+        Assert.Equal(dest, result.PayloadRoot);
+        Assert.True(result.TotalBytes > 0);
+    }
+
+    [Fact]
+    public void VerifyAndExtract_WrongZipHash_RefusesBeforeExtracting()
+    {
+        var (zip, _) = MakeZip(GoodEntries());
+        var dest = Path.Combine(TempDir(), "staged", "NexusApp");
+        Assert.Throws<InvalidOperationException>(() =>
+            PortableUpdater.VerifyAndExtract(zip, new string('a', 64), dest));
+        Assert.False(Directory.Exists(dest));   // nothing may land before the hash gate
+    }
+
+    [Theory]
+    [InlineData("NexusApp/../evil.txt")]
+    [InlineData("NexusApp/install.marker")]
+    [InlineData("NexusApp/x.dll.old")]
+    [InlineData("NexusApp/x.dll.new")]
+    [InlineData("NexusApp/update_journal.json")]
+    [InlineData("NexusApp/update.lock")]
+    [InlineData("NexusApp/update-staging/x.txt")]
+    [InlineData("loose.txt")]
+    public void VerifyAndExtract_HostileEntry_Refuses(string hostile)
+    {
+        var entries = GoodEntries().Append((hostile, "evil")).ToArray();
+        var (zip, hash) = MakeZip(entries);
+        var dest = Path.Combine(TempDir(), "staged", "NexusApp");
+        Assert.Throws<InvalidOperationException>(() => PortableUpdater.VerifyAndExtract(zip, hash, dest));
+    }
+
+    [Fact]
+    public void VerifyAndExtract_MissingExe_Refuses()
+    {
+        var (zip, hash) = MakeZip(("NexusApp/README.txt", "no exe here"));
+        Assert.Throws<InvalidOperationException>(() =>
+            PortableUpdater.VerifyAndExtract(zip, hash, Path.Combine(TempDir(), "s")));
+    }
+
+    [Fact]
+    public void VerifyAndExtract_TooManyEntries_Refuses()
+    {
+        var (zip, hash) = MakeZip(GoodEntries());
+        Assert.Throws<InvalidOperationException>(() =>
+            PortableUpdater.VerifyAndExtract(zip, hash, Path.Combine(TempDir(), "s"), maxEntries: 2));
+    }
+
+    [Fact]
+    public void VerifyAndExtract_ExpansionPastCap_Refuses()
+    {
+        var (zip, hash) = MakeZip(GoodEntries());
+        Assert.Throws<InvalidOperationException>(() =>
+            PortableUpdater.VerifyAndExtract(zip, hash, Path.Combine(TempDir(), "s"), maxBytes: 10));
+    }
+
+    [Fact]
+    public void VerifyAndExtract_ReplacesAStaleStagedTree()
+    {
+        var (zip, hash) = MakeZip(GoodEntries());
+        var dest = Path.Combine(TempDir(), "staged", "NexusApp");
+        Directory.CreateDirectory(dest);
+        File.WriteAllText(Path.Combine(dest, "stale.txt"), "from a crashed run");
+        PortableUpdater.VerifyAndExtract(zip, hash, dest);
+        Assert.False(File.Exists(Path.Combine(dest, "stale.txt")));   // fresh tree every run
+    }
 }

--- a/NexusApp.Tests/PortableUpdaterTests.cs
+++ b/NexusApp.Tests/PortableUpdaterTests.cs
@@ -451,4 +451,250 @@ public class PortableUpdaterTests : IDisposable
         Assert.Equal(PortableApplyOutcome.Completed, result.Outcome);
         Assert.Equal("old exe", File.ReadAllText(Path.Combine(install, "NexusApp.exe.old")));   // the REAL previous exe, not the stale file
     }
+
+    // ---- RecoverAtStartup ----
+
+    private static readonly int[] FastDelays = { 1, 1 };
+
+    private (string install, string journalPath) MakeRecoveryRig()
+    {
+        var root = TempDir();
+        var install = Path.Combine(root, "NexusApp");
+        Directory.CreateDirectory(Path.Combine(install, "Web", "cargo"));
+        return (install, Path.Combine(root, SwapJournal.FileName));
+    }
+
+    [Fact]
+    public void Recover_NoJournal_DoesNothing()
+    {
+        var (install, journalPath) = MakeRecoveryRig();
+        var r = PortableUpdater.RecoverAtStartup(journalPath, install, "6.8.1", FastDelays);
+        Assert.False(r.ShowSwapFailedNotice);
+    }
+
+    [Fact]
+    public void Recover_NoJournalButOrphanStaging_SweepsIt()
+    {
+        // A crash during the staging copy predates the journal: the unclaimed folder must
+        // not sit in the portable root forever (portable-cleanliness rule).
+        var (install, journalPath) = MakeRecoveryRig();
+        Directory.CreateDirectory(Path.Combine(install, PortableUpdater.StagingDirName, "Web"));
+        File.WriteAllText(Path.Combine(install, PortableUpdater.StagingDirName, "half-copied.dll"), "partial");
+        var r = PortableUpdater.RecoverAtStartup(journalPath, install, "6.8.1", FastDelays);
+        Assert.False(r.ShowSwapFailedNotice);
+        Assert.False(Directory.Exists(Path.Combine(install, PortableUpdater.StagingDirName)));
+    }
+
+    [Fact]
+    public void Recover_CompleteJournal_CleansUpAndLeavesNewFiles()
+    {
+        var (install, journalPath) = MakeRecoveryRig();
+        File.WriteAllText(Path.Combine(install, "NexusApp.exe"), "new");
+        File.WriteAllText(Path.Combine(install, "NexusApp.exe.old"), "previous");
+        Directory.CreateDirectory(Path.Combine(install, PortableUpdater.StagingDirName));
+        var j = new SwapJournal
+        {
+            Status = SwapJournal.StatusComplete, AttemptedVersion = "6.9.0", PreviousVersion = "6.8.1",
+            InstallDir = install,
+            Ops = { new SwapOp { Rel = "NexusApp.exe", OldMoved = true, NewPlaced = true } },
+        };
+        j.Save(journalPath);
+        var r = PortableUpdater.RecoverAtStartup(journalPath, install, "6.9.0", FastDelays);
+        Assert.False(r.ShowSwapFailedNotice);
+        Assert.Equal("new", File.ReadAllText(Path.Combine(install, "NexusApp.exe")));
+        Assert.False(File.Exists(Path.Combine(install, "NexusApp.exe.old")));
+        Assert.False(Directory.Exists(Path.Combine(install, PortableUpdater.StagingDirName)));
+        Assert.False(File.Exists(journalPath));
+    }
+
+    [Fact]
+    public void Recover_InProgressJournal_RestoresPreviousVersion()
+    {
+        var (install, journalPath) = MakeRecoveryRig();
+        // Crash state: two files flipped (new in place, .old kept), one new-only file placed.
+        File.WriteAllText(Path.Combine(install, "e_sqlite3.dll"), "new sqlite");
+        File.WriteAllText(Path.Combine(install, "e_sqlite3.dll.old"), "old sqlite");
+        File.WriteAllText(Path.Combine(install, "Web", "cargo", "index.html"), "new page");
+        File.WriteAllText(Path.Combine(install, "Web", "cargo", "index.html.old"), "old page");
+        File.WriteAllText(Path.Combine(install, "brandnew.dll"), "added in 6.9.0");
+        File.WriteAllText(Path.Combine(install, "NexusApp.exe"), "old exe");   // exe never flipped
+        var j = new SwapJournal
+        {
+            Status = SwapJournal.StatusInProgress, AttemptedVersion = "6.9.0", PreviousVersion = "6.8.1",
+            InstallDir = install,
+            Ops =
+            {
+                new SwapOp { Rel = "brandnew.dll", NewPlaced = true },
+                new SwapOp { Rel = "e_sqlite3.dll", OldMoved = true, NewPlaced = true },
+                new SwapOp { Rel = @"Web\cargo\index.html", OldMoved = true, NewPlaced = true },
+            },
+        };
+        j.Save(journalPath);
+        var r = PortableUpdater.RecoverAtStartup(journalPath, install, "6.8.1", FastDelays);
+        Assert.True(r.ShowSwapFailedNotice);
+        Assert.Equal("6.9.0", r.AttemptedVersion);
+        Assert.Equal("old sqlite", File.ReadAllText(Path.Combine(install, "e_sqlite3.dll")));
+        Assert.Equal("old page", File.ReadAllText(Path.Combine(install, "Web", "cargo", "index.html")));
+        Assert.False(File.Exists(Path.Combine(install, "brandnew.dll")));
+        Assert.False(File.Exists(Path.Combine(install, "e_sqlite3.dll.old")));
+        Assert.False(File.Exists(journalPath));
+    }
+
+    [Fact]
+    public void Recover_InProgressButRunningTheNewVersion_HealsToComplete()
+    {
+        var (install, journalPath) = MakeRecoveryRig();
+        File.WriteAllText(Path.Combine(install, "NexusApp.exe"), "new");
+        File.WriteAllText(Path.Combine(install, "NexusApp.exe.old"), "previous");
+        var j = new SwapJournal
+        {
+            Status = SwapJournal.StatusInProgress, AttemptedVersion = "6.9.0", PreviousVersion = "6.8.1",
+            InstallDir = install,
+            Ops = { new SwapOp { Rel = "NexusApp.exe", OldMoved = true, NewPlaced = true } },
+        };
+        j.Save(journalPath);
+        // The crash fell between the last flip and the Complete stamp, but the process now
+        // RUNNING is the attempted version: the swap in fact finished.
+        var r = PortableUpdater.RecoverAtStartup(journalPath, install, "6.9.0", FastDelays);
+        Assert.False(r.ShowSwapFailedNotice);
+        Assert.Equal("new", File.ReadAllText(Path.Combine(install, "NexusApp.exe")));
+        Assert.False(File.Exists(Path.Combine(install, "NexusApp.exe.old")));
+        Assert.False(File.Exists(journalPath));
+    }
+
+    [Fact]
+    public void Recover_HostileRelInJournal_IsIgnored()
+    {
+        var (install, journalPath) = MakeRecoveryRig();
+        var outside = Path.Combine(Path.GetDirectoryName(install)!, "victim.txt");
+        File.WriteAllText(outside, "must survive");
+        File.WriteAllText(outside + ".old", "bait");
+        var j = new SwapJournal
+        {
+            Status = SwapJournal.StatusComplete, AttemptedVersion = "6.9.0", PreviousVersion = "6.8.1",
+            InstallDir = install,
+            Ops = { new SwapOp { Rel = @"..\victim.txt", OldMoved = true, NewPlaced = true } },
+        };
+        j.Save(journalPath);
+        PortableUpdater.RecoverAtStartup(journalPath, install, "6.9.0", FastDelays);
+        Assert.True(File.Exists(outside));           // a tampered journal must never become
+        Assert.True(File.Exists(outside + ".old"));  // a delete primitive outside the install dir
+    }
+
+    [Fact]
+    public void Recover_JournalForAnotherExistingInstall_IsLeftAlone()
+    {
+        var (install, journalPath) = MakeRecoveryRig();
+        var otherInstall = TempDir();
+        File.WriteAllText(Path.Combine(otherInstall, "NexusApp.exe.old"), "other install's rollback");
+        var j = new SwapJournal
+        {
+            Status = SwapJournal.StatusComplete, AttemptedVersion = "6.9.0", PreviousVersion = "6.8.1",
+            InstallDir = otherInstall,
+            Ops = { new SwapOp { Rel = "NexusApp.exe", OldMoved = true, NewPlaced = true } },
+        };
+        j.Save(journalPath);
+        var r = PortableUpdater.RecoverAtStartup(journalPath, install, "6.8.1", FastDelays);
+        Assert.False(r.ShowSwapFailedNotice);
+        Assert.True(File.Exists(journalPath));   // the right instance handles it; the purge guard keeps its zip safe
+        Assert.True(File.Exists(Path.Combine(otherInstall, "NexusApp.exe.old")));
+    }
+
+    [Fact]
+    public void Recover_JournalForAVanishedInstall_IsDiscarded()
+    {
+        var (install, journalPath) = MakeRecoveryRig();
+        var j = new SwapJournal
+        {
+            Status = SwapJournal.StatusComplete, AttemptedVersion = "6.9.0", PreviousVersion = "6.8.1",
+            InstallDir = Path.Combine(Path.GetTempPath(), "nexus-gone-" + Path.GetRandomFileName()),
+        };
+        j.Save(journalPath);
+        var r = PortableUpdater.RecoverAtStartup(journalPath, install, "6.8.1", FastDelays);
+        Assert.False(r.ShowSwapFailedNotice);
+        Assert.False(File.Exists(journalPath));
+    }
+
+    [Fact]
+    public void Recover_GarbageJournal_IsDiscarded()
+    {
+        var (install, journalPath) = MakeRecoveryRig();
+        File.WriteAllText(journalPath, "{ not a journal");
+        var r = PortableUpdater.RecoverAtStartup(journalPath, install, "6.8.1", FastDelays);
+        Assert.False(r.ShowSwapFailedNotice);
+        Assert.False(File.Exists(journalPath));
+    }
+
+    [Fact]
+    public void Recover_LockedOldFile_KeepsJournalForALaterStart()
+    {
+        var (install, journalPath) = MakeRecoveryRig();
+        File.WriteAllText(Path.Combine(install, "NexusApp.exe"), "new");
+        File.WriteAllText(Path.Combine(install, "NexusApp.exe.old"), "previous");
+        var j = new SwapJournal
+        {
+            Status = SwapJournal.StatusComplete, AttemptedVersion = "6.9.0", PreviousVersion = "6.8.1",
+            InstallDir = install,
+            Ops = { new SwapOp { Rel = "NexusApp.exe", OldMoved = true, NewPlaced = true } },
+        };
+        j.Save(journalPath);
+        using var holder = new FileStream(Path.Combine(install, "NexusApp.exe.old"),
+            FileMode.Open, FileAccess.Read, FileShare.Read);   // no delete sharing: purge must fail quietly
+        var r = PortableUpdater.RecoverAtStartup(journalPath, install, "6.9.0", FastDelays);
+        Assert.False(r.ShowSwapFailedNotice);
+        Assert.True(File.Exists(journalPath));   // retried on a later start (CFA / delete-lock tolerance)
+    }
+
+    [Fact]
+    public void Recover_SecondPassAfterPartialRestore_NeverDeletesRestoredFiles()
+    {
+        // Pass 1 restores index.html but cannot restore e_sqlite3.dll (its .old is held).
+        // Pass 2 must finish the blocked op WITHOUT deleting what pass 1 already restored:
+        // a restored file (old bytes at the live name, .old consumed, flags stale) must not
+        // be mistaken for a new-only file.
+        var (install, journalPath) = MakeRecoveryRig();
+        File.WriteAllText(Path.Combine(install, "e_sqlite3.dll"), "new sqlite");
+        File.WriteAllText(Path.Combine(install, "e_sqlite3.dll.old"), "old sqlite");
+        File.WriteAllText(Path.Combine(install, "Web", "cargo", "index.html"), "new page");
+        File.WriteAllText(Path.Combine(install, "Web", "cargo", "index.html.old"), "old page");
+        var j = new SwapJournal
+        {
+            Status = SwapJournal.StatusInProgress, AttemptedVersion = "6.9.0", PreviousVersion = "6.8.1",
+            InstallDir = install,
+            Ops =
+            {
+                new SwapOp { Rel = "e_sqlite3.dll", OldMoved = true, NewPlaced = true },
+                new SwapOp { Rel = @"Web\cargo\index.html", OldMoved = true, NewPlaced = true },
+            },
+        };
+        j.Save(journalPath);
+        using (var holder = new FileStream(Path.Combine(install, "e_sqlite3.dll.old"),
+            FileMode.Open, FileAccess.Read, FileShare.Read))
+        {
+            var first = PortableUpdater.RecoverAtStartup(journalPath, install, "6.8.1", FastDelays);
+            Assert.True(first.ShowSwapFailedNotice);
+            Assert.True(File.Exists(journalPath));   // blocked op keeps the journal for a later start
+            Assert.Equal("old page", File.ReadAllText(Path.Combine(install, "Web", "cargo", "index.html")));
+        }
+        var second = PortableUpdater.RecoverAtStartup(journalPath, install, "6.8.1", FastDelays);
+        Assert.True(second.ShowSwapFailedNotice);
+        Assert.Equal("old page", File.ReadAllText(Path.Combine(install, "Web", "cargo", "index.html")));
+        Assert.Equal("old sqlite", File.ReadAllText(Path.Combine(install, "e_sqlite3.dll")));
+        Assert.False(File.Exists(journalPath));
+    }
+
+    [Fact]
+    public void Recover_OrphanStagingWhileUpdateLockHeld_LeavesIt()
+    {
+        // The no-journal window includes a LIVE Apply mid-staging-copy; the sweep must yield
+        // to whoever holds the update lock instead of deleting their half-copied payload.
+        var (install, journalPath) = MakeRecoveryRig();
+        Directory.CreateDirectory(Path.Combine(install, PortableUpdater.StagingDirName));
+        File.WriteAllText(Path.Combine(install, PortableUpdater.StagingDirName, "half-copied.dll"), "partial");
+        using var lockHolder = new FileStream(Path.Combine(install, PortableUpdater.LockFileName),
+            FileMode.Create, FileAccess.Write, FileShare.None);
+        var r = PortableUpdater.RecoverAtStartup(journalPath, install, "6.8.1", FastDelays);
+        Assert.False(r.ShowSwapFailedNotice);
+        Assert.True(File.Exists(Path.Combine(install, PortableUpdater.StagingDirName, "half-copied.dll")));
+    }
 }

--- a/NexusApp.Tests/PortableUpdaterTests.cs
+++ b/NexusApp.Tests/PortableUpdaterTests.cs
@@ -1,0 +1,156 @@
+using NexusApp.Services;
+using Xunit;
+
+namespace NexusApp.Tests;
+
+public class PortableUpdaterTests : IDisposable
+{
+    private readonly List<string> _tempDirs = new();
+
+    public void Dispose()
+    {
+        foreach (var d in _tempDirs)
+        {
+            try { if (Directory.Exists(d)) Directory.Delete(d, recursive: true); }
+            catch { /* best effort */ }
+        }
+    }
+
+    private string TempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "nexus-swap-test-" + Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        _tempDirs.Add(dir);
+        return dir;
+    }
+
+    // A PortableEnv whose special folders all live inside one throwaway tree, so the
+    // path-shape rules can be exercised without touching the real machine's folders.
+    private (PortableEnv env, string root) FakeEnv()
+    {
+        var root = TempDir();
+        var env = new PortableEnv(
+            TempPath: Path.Combine(root, "Temp"),
+            ProgramFiles: Path.Combine(root, "Program Files"),
+            ProgramFilesX86: Path.Combine(root, "Program Files (x86)"),
+            WindowsDir: Path.Combine(root, "Windows"),
+            LocalAppData: Path.Combine(root, "LocalAppData"),
+            AppDataRoot: Path.Combine(root, "AppData", "NexusApp"));
+        return (env, root);
+    }
+
+    // ---- PreflightPathIssue (pure path-shape rules) ----
+
+    [Fact]
+    public void PreflightPathIssue_HappyPath_ReturnsNull()
+    {
+        var (env, root) = FakeEnv();
+        var install = Path.Combine(root, "PortableApps", "NexusApp");
+        Assert.Null(PortableUpdater.PreflightPathIssue(Path.Combine(install, "NexusApp.exe"), install, env));
+    }
+
+    [Fact]
+    public void PreflightPathIssue_NullProcessPath_Refuses()
+    {
+        var (env, root) = FakeEnv();
+        Assert.NotNull(PortableUpdater.PreflightPathIssue(null, Path.Combine(root, "x"), env));
+    }
+
+    [Fact]
+    public void PreflightPathIssue_RenamedExe_Refuses()
+    {
+        var (env, root) = FakeEnv();
+        var install = Path.Combine(root, "x");
+        Assert.NotNull(PortableUpdater.PreflightPathIssue(Path.Combine(install, "MyNexus.exe"), install, env));
+    }
+
+    [Fact]
+    public void PreflightPathIssue_ProcessDirDisagreesWithBaseDir_Refuses()
+    {
+        var (env, root) = FakeEnv();
+        Assert.NotNull(PortableUpdater.PreflightPathIssue(
+            Path.Combine(root, "a", "NexusApp.exe"), Path.Combine(root, "b"), env));
+    }
+
+    [Theory]
+    [InlineData("Temp")]                    // %TEMP% (7-Zip transient extraction)
+    [InlineData("Program Files")]
+    [InlineData("Program Files (x86)")]
+    [InlineData("Windows")]
+    public void PreflightPathIssue_ForbiddenRoots_Refuse(string sub)
+    {
+        var (env, root) = FakeEnv();
+        var install = Path.Combine(root, sub, "NexusApp");
+        Assert.NotNull(PortableUpdater.PreflightPathIssue(Path.Combine(install, "NexusApp.exe"), install, env));
+    }
+
+    [Fact]
+    public void PreflightPathIssue_AppDataRoot_Refuses()
+    {
+        var (env, root) = FakeEnv();
+        var install = Path.Combine(root, "AppData", "NexusApp", "updates", "6.9.0", "staged", "NexusApp");
+        Assert.NotNull(PortableUpdater.PreflightPathIssue(Path.Combine(install, "NexusApp.exe"), install, env));
+    }
+
+    [Fact]
+    public void PreflightPathIssue_InstallerLocation_Refuses()
+    {
+        var (env, root) = FakeEnv();
+        var install = Path.Combine(root, "LocalAppData", "Nexus");
+        Assert.NotNull(PortableUpdater.PreflightPathIssue(Path.Combine(install, "NexusApp.exe"), install, env));
+    }
+
+    [Fact]
+    public void PreflightPathIssue_UncPath_Refuses()
+    {
+        var (env, _) = FakeEnv();
+        Assert.NotNull(PortableUpdater.PreflightPathIssue(
+            @"\\server\share\NexusApp\NexusApp.exe", @"\\server\share\NexusApp", env));
+    }
+
+    [Fact]
+    public void PreflightPathIssue_OverlongPath_Refuses()
+    {
+        var (env, root) = FakeEnv();
+        var install = Path.Combine(root, new string('a', 210));
+        Assert.NotNull(PortableUpdater.PreflightPathIssue(Path.Combine(install, "NexusApp.exe"), install, env));
+    }
+
+    // ---- NormalizeEntry (zip entry hardening) ----
+
+    [Theory]
+    [InlineData("NexusApp/NexusApp.exe", "NexusApp.exe")]
+    [InlineData("NexusApp/Web/cargo/index.html", @"Web\cargo\index.html")]
+    [InlineData(@"NexusApp\e_sqlite3.dll", "e_sqlite3.dll")]
+    [InlineData("NexusApp/", "")]                 // the top-level folder entry itself
+    [InlineData("NexusApp/Web/", "Web")]          // directory entry
+    public void NormalizeEntry_Accepts(string entry, string expectedRel)
+    {
+        Assert.Null(PortableUpdater.NormalizeEntry(entry, out var rel));
+        Assert.Equal(expectedRel, rel);
+    }
+
+    [Theory]
+    [InlineData("loose.txt")]                          // outside the NexusApp top folder
+    [InlineData("Other/NexusApp.exe")]
+    [InlineData("NexusApp/../evil.txt")]               // traversal
+    [InlineData(@"NexusApp\..\evil.txt")]
+    [InlineData("/NexusApp/NexusApp.exe")]             // rooted
+    [InlineData(@"C:\NexusApp\NexusApp.exe")]          // drive letter (also caught by colon)
+    [InlineData("NexusApp/a:b.txt")]                   // alternate data stream
+    [InlineData("NexusApp/install.marker")]            // would flip Distribution to Installer
+    [InlineData("NexusApp/Web/install.marker")]
+    [InlineData("NexusApp/update_journal.json")]       // collides with swap bookkeeping
+    [InlineData("NexusApp/update.lock")]
+    [InlineData("NexusApp/NexusApp.exe.old")]
+    [InlineData("NexusApp/e_sqlite3.dll.new")]
+    [InlineData("NexusApp/update-staging/x.txt")]
+    [InlineData("NexusApp/CON.txt")]                   // reserved device name
+    [InlineData("NexusApp/lpt1")]
+    [InlineData("NexusApp/trailingdot./x.txt")]
+    [InlineData("NexusApp/trailing.dll ")]             // trailing space
+    [InlineData("NexusApp/./x.txt")]
+    [InlineData("")]
+    public void NormalizeEntry_Rejects(string entry) =>
+        Assert.NotNull(PortableUpdater.NormalizeEntry(entry, out _));
+}

--- a/NexusApp.Tests/PortableUpdaterTests.cs
+++ b/NexusApp.Tests/PortableUpdaterTests.cs
@@ -697,4 +697,40 @@ public class PortableUpdaterTests : IDisposable
         Assert.False(r.ShowSwapFailedNotice);
         Assert.True(File.Exists(Path.Combine(install, PortableUpdater.StagingDirName, "half-copied.dll")));
     }
+
+    // ---- UnpackForManual ----
+
+    [Fact]
+    public void UnpackForManual_ExtractsAndOpensBothFolders()
+    {
+        var (env, root) = FakeEnv();
+        var install = Path.Combine(root, "PortableApps", "NexusApp");
+        Directory.CreateDirectory(install);
+        var updates = Path.Combine(root, "AppData", "NexusApp", "updates");
+        var opened = new List<string>();
+        var (zip, hash) = MakeZip(GoodEntries());
+        var up = new PortableUpdater(install, Path.Combine(install, "NexusApp.exe"), updates,
+            Path.Combine(root, SwapJournal.FileName), () => "Portable", env,
+            retryDelaysMs: new[] { 1, 1 }, nexusProcessCount: () => 1, openFolder: opened.Add);
+        Assert.True(up.UnpackForManual(zip, hash, new Version(6, 9, 0)));
+        var staged = Path.Combine(updates, "6.9.0", "staged", "NexusApp");
+        Assert.Equal("new exe bytes", File.ReadAllText(Path.Combine(staged, "NexusApp.exe")));
+        Assert.Equal(new[] { staged, install }, opened);
+    }
+
+    [Fact]
+    public void UnpackForManual_BadHash_FailsAndOpensNothing()
+    {
+        var (env, root) = FakeEnv();
+        var install = Path.Combine(root, "PortableApps", "NexusApp");
+        Directory.CreateDirectory(install);
+        var opened = new List<string>();
+        var (zip, _) = MakeZip(GoodEntries());
+        var up = new PortableUpdater(install, Path.Combine(install, "NexusApp.exe"),
+            Path.Combine(root, "updates"), Path.Combine(root, SwapJournal.FileName),
+            () => "Portable", env, retryDelaysMs: new[] { 1, 1 }, nexusProcessCount: () => 1,
+            openFolder: opened.Add);
+        Assert.False(up.UnpackForManual(zip, new string('a', 64), new Version(6, 9, 0)));
+        Assert.Empty(opened);
+    }
 }

--- a/NexusApp.Tests/PortableUpdaterTests.cs
+++ b/NexusApp.Tests/PortableUpdaterTests.cs
@@ -452,6 +452,57 @@ public class PortableUpdaterTests : IDisposable
         Assert.Equal("old exe", File.ReadAllText(Path.Combine(install, "NexusApp.exe.old")));   // the REAL previous exe, not the stale file
     }
 
+    [Fact]
+    public void Apply_JournalPresent_RefusesAndKeepsItByteIdentical()
+    {
+        // A journal on disk is unfinished business only startup recovery may resolve: its
+        // .old files can be the only copy of a previous version, and a fresh swap would
+        // overwrite the journal and delete them.
+        var (up, install, _, journal, zip, hash) = MakeApplyRig();
+        new SwapJournal
+        {
+            Status = SwapJournal.StatusInProgress, AttemptedVersion = "6.9.0", PreviousVersion = "6.8.1",
+            InstallDir = install,
+            Ops = { new SwapOp { Rel = "e_sqlite3.dll", OldMoved = true } },
+        }.Save(journal);
+        var before = File.ReadAllBytes(journal);
+        var result = up.Apply(zip, hash, new Version(6, 9, 0), "6.8.1");
+        Assert.Equal(PortableApplyOutcome.FailedNothingChanged, result.Outcome);
+        Assert.Contains("previous update has not finished", result.Reason);
+        Assert.Equal("old exe", File.ReadAllText(Path.Combine(install, "NexusApp.exe")));
+        Assert.Equal(before, File.ReadAllBytes(journal));
+        Assert.False(Directory.Exists(Path.Combine(install, PortableUpdater.StagingDirName)));
+    }
+
+    [Fact]
+    public void Apply_RollbackStuck_KeepsTheJournalInProgressAndTheOldFiles()
+    {
+        // The one path that leaves the folder mid-rollback: e_sqlite3.dll has already flipped
+        // when the exe's re-hash fails, and its new file is held so the reverse rename cannot
+        // unwind it. The journal must stay on disk as InProgress (a Complete stamp would send
+        // the next start down the cleanup branch and delete the .old set) with the blocked
+        // op's previous bytes intact.
+        var (up, install, _, journal, zip, hash) = MakeApplyRig();
+        FileStream? hold = null;
+        up.BeforeFlipHook = (stagedPath, rel) =>
+        {
+            if (rel != "NexusApp.exe") return;   // the exe flips last, after every other file
+            hold = new FileStream(Path.Combine(install, "e_sqlite3.dll"),
+                FileMode.Open, FileAccess.Read, FileShare.Read);
+            File.WriteAllText(stagedPath, "tampered after extraction");
+        };
+        try
+        {
+            var result = up.Apply(zip, hash, new Version(6, 9, 0), "6.8.1");
+            Assert.Equal(PortableApplyOutcome.FailedRollbackIncomplete, result.Outcome);
+            var back = SwapJournal.TryLoad(journal);
+            Assert.NotNull(back);
+            Assert.Equal(SwapJournal.StatusInProgress, back!.Status);
+            Assert.Equal("old sqlite", File.ReadAllText(Path.Combine(install, "e_sqlite3.dll.old")));
+        }
+        finally { hold?.Dispose(); }
+    }
+
     // ---- RecoverAtStartup ----
 
     private static readonly int[] FastDelays = { 1, 1 };
@@ -537,6 +588,55 @@ public class PortableUpdaterTests : IDisposable
         Assert.Equal("old page", File.ReadAllText(Path.Combine(install, "Web", "cargo", "index.html")));
         Assert.False(File.Exists(Path.Combine(install, "brandnew.dll")));
         Assert.False(File.Exists(Path.Combine(install, "e_sqlite3.dll.old")));
+        // The restore vacates the live name by RENAMING the new file aside (a mapped image
+        // can never be deleted), so the parked .new must be gone by the end of a clean pass.
+        Assert.False(File.Exists(Path.Combine(install, "e_sqlite3.dll" + PortableUpdater.NewSuffix)));
+        Assert.False(File.Exists(Path.Combine(install, "Web", "cargo", "index.html" + PortableUpdater.NewSuffix)));
+        Assert.False(File.Exists(journalPath));
+    }
+
+    [Fact]
+    public void Recover_StaleNewFile_DoesNotBreakTheRestore()
+    {
+        // Residue from an earlier interrupted pass sits at the name the vacate rename needs;
+        // it is cleared first instead of wedging the restore.
+        var (install, journalPath) = MakeRecoveryRig();
+        File.WriteAllText(Path.Combine(install, "e_sqlite3.dll"), "new sqlite");
+        File.WriteAllText(Path.Combine(install, "e_sqlite3.dll.old"), "old sqlite");
+        File.WriteAllText(Path.Combine(install, "e_sqlite3.dll" + PortableUpdater.NewSuffix), "residue");
+        var j = new SwapJournal
+        {
+            Status = SwapJournal.StatusInProgress, AttemptedVersion = "6.9.0", PreviousVersion = "6.8.1",
+            InstallDir = install,
+            Ops = { new SwapOp { Rel = "e_sqlite3.dll", OldMoved = true, NewPlaced = true } },
+        };
+        j.Save(journalPath);
+        var r = PortableUpdater.RecoverAtStartup(journalPath, install, "6.8.1", FastDelays);
+        Assert.True(r.ShowSwapFailedNotice);
+        Assert.Equal("old sqlite", File.ReadAllText(Path.Combine(install, "e_sqlite3.dll")));
+        Assert.False(File.Exists(Path.Combine(install, "e_sqlite3.dll" + PortableUpdater.NewSuffix)));
+        Assert.False(File.Exists(journalPath));
+    }
+
+    [Fact]
+    public void Recover_CompleteJournal_SweepsALeftoverNewFile()
+    {
+        // A restore attempt that parked a .new can later heal into the completed branch (the
+        // running exe turns out to BE the attempted version); the cleanup owns the residue.
+        var (install, journalPath) = MakeRecoveryRig();
+        File.WriteAllText(Path.Combine(install, "NexusApp.exe"), "new");
+        File.WriteAllText(Path.Combine(install, "NexusApp.exe" + PortableUpdater.NewSuffix), "parked by an earlier pass");
+        var j = new SwapJournal
+        {
+            Status = SwapJournal.StatusComplete, AttemptedVersion = "6.9.0", PreviousVersion = "6.8.1",
+            InstallDir = install,
+            Ops = { new SwapOp { Rel = "NexusApp.exe", OldMoved = true, NewPlaced = true } },
+        };
+        j.Save(journalPath);
+        var r = PortableUpdater.RecoverAtStartup(journalPath, install, "6.9.0", FastDelays);
+        Assert.False(r.ShowSwapFailedNotice);
+        Assert.Equal("new", File.ReadAllText(Path.Combine(install, "NexusApp.exe")));
+        Assert.False(File.Exists(Path.Combine(install, "NexusApp.exe" + PortableUpdater.NewSuffix)));
         Assert.False(File.Exists(journalPath));
     }
 
@@ -558,6 +658,28 @@ public class PortableUpdaterTests : IDisposable
         var r = PortableUpdater.RecoverAtStartup(journalPath, install, "6.9.0", FastDelays);
         Assert.False(r.ShowSwapFailedNotice);
         Assert.Equal("new", File.ReadAllText(Path.Combine(install, "NexusApp.exe")));
+        Assert.False(File.Exists(Path.Combine(install, "NexusApp.exe.old")));
+        Assert.False(File.Exists(journalPath));
+    }
+
+    [Fact]
+    public void Recover_InProgressButRunningANewerVersion_HealsToComplete()
+    {
+        // The guided manual flow can land a copy NEWER than the crashed swap attempted;
+        // restoring the .old set over it would build a mixed folder.
+        var (install, journalPath) = MakeRecoveryRig();
+        File.WriteAllText(Path.Combine(install, "NexusApp.exe"), "manually copied 6.9.1");
+        File.WriteAllText(Path.Combine(install, "NexusApp.exe.old"), "previous");
+        var j = new SwapJournal
+        {
+            Status = SwapJournal.StatusInProgress, AttemptedVersion = "6.9.0", PreviousVersion = "6.8.1",
+            InstallDir = install,
+            Ops = { new SwapOp { Rel = "NexusApp.exe", OldMoved = true, NewPlaced = true } },
+        };
+        j.Save(journalPath);
+        var r = PortableUpdater.RecoverAtStartup(journalPath, install, "6.9.1", FastDelays);
+        Assert.False(r.ShowSwapFailedNotice);
+        Assert.Equal("manually copied 6.9.1", File.ReadAllText(Path.Combine(install, "NexusApp.exe")));
         Assert.False(File.Exists(Path.Combine(install, "NexusApp.exe.old")));
         Assert.False(File.Exists(journalPath));
     }
@@ -675,11 +797,49 @@ public class PortableUpdaterTests : IDisposable
             Assert.True(first.ShowSwapFailedNotice);
             Assert.True(File.Exists(journalPath));   // blocked op keeps the journal for a later start
             Assert.Equal("old page", File.ReadAllText(Path.Combine(install, "Web", "cargo", "index.html")));
+            // The blocked op vacated the live name and then could not restore: the new file
+            // goes BACK so the folder stays bootable and no .new residue is left behind.
+            Assert.Equal("new sqlite", File.ReadAllText(Path.Combine(install, "e_sqlite3.dll")));
+            Assert.False(File.Exists(Path.Combine(install, "e_sqlite3.dll" + PortableUpdater.NewSuffix)));
         }
         var second = PortableUpdater.RecoverAtStartup(journalPath, install, "6.8.1", FastDelays);
         Assert.True(second.ShowSwapFailedNotice);
         Assert.Equal("old page", File.ReadAllText(Path.Combine(install, "Web", "cargo", "index.html")));
         Assert.Equal("old sqlite", File.ReadAllText(Path.Combine(install, "e_sqlite3.dll")));
+        Assert.False(File.Exists(Path.Combine(install, "e_sqlite3.dll" + PortableUpdater.NewSuffix)));
+        Assert.False(File.Exists(journalPath));
+    }
+
+    [Fact]
+    public void Recover_ReEntryWithAnEmptyLiveName_PutsTheParkedFileBack()
+    {
+        // A crash inside the vacate-then-restore window leaves a start that BEGINS with an
+        // empty live name and the new file waiting at .new. If the .old restore fails again,
+        // the parked file must go back: a hole where a native the app loads used to be would
+        // be worse than the wrong version sitting there.
+        var (install, journalPath) = MakeRecoveryRig();
+        File.WriteAllText(Path.Combine(install, "e_sqlite3.dll" + PortableUpdater.NewSuffix), "new sqlite");
+        File.WriteAllText(Path.Combine(install, "e_sqlite3.dll.old"), "old sqlite");
+        var j = new SwapJournal
+        {
+            Status = SwapJournal.StatusInProgress, AttemptedVersion = "6.9.0", PreviousVersion = "6.8.1",
+            InstallDir = install,
+            Ops = { new SwapOp { Rel = "e_sqlite3.dll", OldMoved = true, NewPlaced = true } },
+        };
+        j.Save(journalPath);
+        using (var holder = new FileStream(Path.Combine(install, "e_sqlite3.dll.old"),
+            FileMode.Open, FileAccess.Read, FileShare.Read))
+        {
+            var first = PortableUpdater.RecoverAtStartup(journalPath, install, "6.8.1", FastDelays);
+            Assert.True(first.ShowSwapFailedNotice);
+            Assert.Equal("new sqlite", File.ReadAllText(Path.Combine(install, "e_sqlite3.dll")));
+            Assert.False(File.Exists(Path.Combine(install, "e_sqlite3.dll" + PortableUpdater.NewSuffix)));
+            Assert.True(File.Exists(journalPath));   // still blocked: a later start finishes it
+        }
+        var second = PortableUpdater.RecoverAtStartup(journalPath, install, "6.8.1", FastDelays);
+        Assert.True(second.ShowSwapFailedNotice);
+        Assert.Equal("old sqlite", File.ReadAllText(Path.Combine(install, "e_sqlite3.dll")));
+        Assert.False(File.Exists(Path.Combine(install, "e_sqlite3.dll" + PortableUpdater.NewSuffix)));
         Assert.False(File.Exists(journalPath));
     }
 

--- a/NexusApp.Tests/PortableUpdaterTests.cs
+++ b/NexusApp.Tests/PortableUpdaterTests.cs
@@ -259,4 +259,196 @@ public class PortableUpdaterTests : IDisposable
         PortableUpdater.VerifyAndExtract(zip, hash, dest);
         Assert.False(File.Exists(Path.Combine(dest, "stale.txt")));   // fresh tree every run
     }
+
+    // ---- Preflight (instance probes) + Apply (flip engine) ----
+
+    // A fake portable install with the layout-probe DLLs, plus an updater wired to it with
+    // millisecond retries and every environment seam pointed at throwaway dirs.
+    private (PortableUpdater up, string install, string updates, string journal, string zip, string zipHash)
+        MakeApplyRig(string currentOnDisk = "old", Func<int>? processCount = null, Func<string>? distribution = null)
+    {
+        var (env, root) = FakeEnv();
+        var install = Path.Combine(root, "PortableApps", "NexusApp");
+        Directory.CreateDirectory(Path.Combine(install, "Web", "cargo"));
+        File.WriteAllText(Path.Combine(install, "NexusApp.exe"), currentOnDisk + " exe");
+        File.WriteAllText(Path.Combine(install, "e_sqlite3.dll"), currentOnDisk + " sqlite");
+        File.WriteAllText(Path.Combine(install, "wpfgfx_cor3.dll"), currentOnDisk + " wpf");
+        File.WriteAllText(Path.Combine(install, "README.txt"), currentOnDisk + " readme");
+        File.WriteAllText(Path.Combine(install, "Web", "cargo", "index.html"), currentOnDisk + " page");
+        var updates = Path.Combine(root, "AppData", "NexusApp", "updates");
+        var journal = Path.Combine(root, "AppData", "NexusApp", SwapJournal.FileName);
+        Directory.CreateDirectory(Path.GetDirectoryName(journal)!);
+        var (zip, zipHash) = MakeZip(GoodEntries());
+        var up = new PortableUpdater(install, Path.Combine(install, "NexusApp.exe"), updates, journal,
+            distribution ?? (() => "Portable"), env,
+            retryDelaysMs: new[] { 1, 1 }, nexusProcessCount: processCount ?? (() => 1),
+            openFolder: _ => { });
+        return (up, install, updates, journal, zip, zipHash);
+    }
+
+    [Fact]
+    public void Preflight_HappyPath_Ok()
+    {
+        var (up, _, _, _, _, _) = MakeApplyRig();
+        var pre = up.Preflight(1000);
+        Assert.True(pre.Ok);
+    }
+
+    [Fact]
+    public void Preflight_MissingLayoutDlls_Refuses()
+    {
+        var (up, install, _, _, _, _) = MakeApplyRig();
+        File.Delete(Path.Combine(install, "e_sqlite3.dll"));
+        Assert.False(up.Preflight(1000).Ok);
+    }
+
+    [Fact]
+    public void Preflight_SecondInstance_Refuses()
+    {
+        var (up, _, _, _, _, _) = MakeApplyRig(processCount: () => 2);
+        var pre = up.Preflight(1000);
+        Assert.False(pre.Ok);
+        Assert.Contains("another Nexus", pre.Reason);
+    }
+
+    [Fact]
+    public void Preflight_NotPortableDistribution_Refuses()
+    {
+        var (up, _, _, _, _, _) = MakeApplyRig(distribution: () => "Installer");
+        Assert.False(up.Preflight(1000).Ok);
+    }
+
+    [Fact]
+    public void Apply_HappyPath_FlipsEverythingAndJournalsComplete()
+    {
+        var (up, install, _, journal, zip, hash) = MakeApplyRig();
+        var result = up.Apply(zip, hash, new Version(6, 9, 0), "6.8.1");
+        Assert.Equal(PortableApplyOutcome.Completed, result.Outcome);
+        Assert.Equal("new exe bytes", File.ReadAllText(Path.Combine(install, "NexusApp.exe")));
+        Assert.Equal("new page", File.ReadAllText(Path.Combine(install, "Web", "cargo", "index.html")));
+        Assert.Equal("old exe", File.ReadAllText(Path.Combine(install, "NexusApp.exe.old")));
+        Assert.False(Directory.Exists(Path.Combine(install, PortableUpdater.StagingDirName)));
+        Assert.True(File.Exists(zip));   // the crash-recovery artifact survives until the new version's first start
+        var back = SwapJournal.TryLoad(journal);
+        Assert.NotNull(back);
+        Assert.Equal(SwapJournal.StatusComplete, back!.Status);
+        Assert.Equal("6.9.0", back.AttemptedVersion);
+        Assert.False(File.Exists(Path.Combine(install, PortableUpdater.LockFileName)));   // DeleteOnClose
+    }
+
+    [Fact]
+    public void Apply_NotAnUpgrade_RefusesUntouched()
+    {
+        var (up, install, _, journal, zip, hash) = MakeApplyRig();
+        var result = up.Apply(zip, hash, new Version(6, 9, 0), "6.9.0");   // same version: not strictly greater
+        Assert.Equal(PortableApplyOutcome.FailedNothingChanged, result.Outcome);
+        Assert.Equal("old exe", File.ReadAllText(Path.Combine(install, "NexusApp.exe")));
+        Assert.False(File.Exists(journal));
+    }
+
+    [Fact]
+    public void Apply_WrongHash_RefusesUntouched()
+    {
+        var (up, install, _, journal, zip, _) = MakeApplyRig();
+        var result = up.Apply(zip, new string('a', 64), new Version(6, 9, 0), "6.8.1");
+        Assert.Equal(PortableApplyOutcome.FailedNothingChanged, result.Outcome);
+        Assert.Equal("old exe", File.ReadAllText(Path.Combine(install, "NexusApp.exe")));
+        Assert.False(File.Exists(journal));
+    }
+
+    [Fact]
+    public void Apply_LockedCriticalFile_RollsBackCompletely()
+    {
+        var (up, install, _, journal, zip, hash) = MakeApplyRig();
+        // Web\cargo\index.html held open WITHOUT FileShare.Delete: its rename-out must fail.
+        using var holder = new FileStream(Path.Combine(install, "Web", "cargo", "index.html"),
+            FileMode.Open, FileAccess.Read, FileShare.Read);
+        var result = up.Apply(zip, hash, new Version(6, 9, 0), "6.8.1");
+        Assert.Equal(PortableApplyOutcome.FailedRolledBack, result.Outcome);
+        Assert.Equal("old exe", File.ReadAllText(Path.Combine(install, "NexusApp.exe")));
+        Assert.Equal("old sqlite", File.ReadAllText(Path.Combine(install, "e_sqlite3.dll")));
+        Assert.Equal("old page", File.ReadAllText(Path.Combine(install, "Web", "cargo", "index.html")));
+        Assert.False(File.Exists(Path.Combine(install, "NexusApp.exe.old")));
+        Assert.False(File.Exists(journal));
+        Assert.False(Directory.Exists(Path.Combine(install, PortableUpdater.StagingDirName)));
+    }
+
+    [Fact]
+    public void Apply_LockedReadme_SkipsItAndCompletes()
+    {
+        var (up, install, _, journal, zip, hash) = MakeApplyRig();
+        using var holder = new FileStream(Path.Combine(install, "README.txt"),
+            FileMode.Open, FileAccess.Read, FileShare.Read);
+        var result = up.Apply(zip, hash, new Version(6, 9, 0), "6.8.1");
+        Assert.Equal(PortableApplyOutcome.Completed, result.Outcome);
+        Assert.Equal("old readme", File.ReadAllText(Path.Combine(install, "README.txt")));   // kept, not fatal
+        Assert.Equal("new exe bytes", File.ReadAllText(Path.Combine(install, "NexusApp.exe")));
+        var back = SwapJournal.TryLoad(journal);
+        Assert.Contains(back!.Ops, o => o.Rel == "README.txt" && o.Skipped);
+    }
+
+    [Fact]
+    public void Apply_StagedTamper_RollsBack()
+    {
+        var (up, install, _, _, zip, hash) = MakeApplyRig();
+        up.BeforeFlipHook = (stagedPath, rel) =>
+        {
+            if (rel == "e_sqlite3.dll") File.WriteAllText(stagedPath, "tampered after extraction");
+        };
+        var result = up.Apply(zip, hash, new Version(6, 9, 0), "6.8.1");
+        Assert.Equal(PortableApplyOutcome.FailedRolledBack, result.Outcome);
+        Assert.Contains("changed between unpack and install", result.Reason);
+        Assert.Equal("old exe", File.ReadAllText(Path.Combine(install, "NexusApp.exe")));
+        Assert.Equal("old sqlite", File.ReadAllText(Path.Combine(install, "e_sqlite3.dll")));
+    }
+
+    [Fact]
+    public void Apply_LockHeld_RefusesUntouched()
+    {
+        var (up, install, _, _, zip, hash) = MakeApplyRig();
+        using var lockHolder = new FileStream(Path.Combine(install, PortableUpdater.LockFileName),
+            FileMode.Create, FileAccess.Write, FileShare.None);
+        var result = up.Apply(zip, hash, new Version(6, 9, 0), "6.8.1");
+        Assert.Equal(PortableApplyOutcome.FailedNothingChanged, result.Outcome);
+        Assert.Contains("already in progress", result.Reason);
+    }
+
+    [Fact]
+    public void Apply_UnwritableJournal_RefusesBeforeAnyRename()
+    {
+        var (_, install, updates, _, zip, hash) = MakeApplyRig();
+        // A journal path that is a DIRECTORY makes the write-ahead save throw; the swap must
+        // abort before the first rename and clean its staging folder out of the install dir.
+        var badJournal = Path.Combine(Path.GetDirectoryName(install)!, "journal-as-dir");
+        Directory.CreateDirectory(badJournal);
+        var env = FakeEnvFor(install);
+        var up = new PortableUpdater(install, Path.Combine(install, "NexusApp.exe"), updates, badJournal,
+            () => "Portable", env, retryDelaysMs: new[] { 1, 1 }, nexusProcessCount: () => 1, openFolder: _ => { });
+        var result = up.Apply(zip, hash, new Version(6, 9, 0), "6.8.1");
+        Assert.Equal(PortableApplyOutcome.FailedNothingChanged, result.Outcome);
+        Assert.Equal("old exe", File.ReadAllText(Path.Combine(install, "NexusApp.exe")));
+        Assert.False(File.Exists(Path.Combine(install, "NexusApp.exe.old")));
+        Assert.False(Directory.Exists(Path.Combine(install, PortableUpdater.StagingDirName)));
+    }
+
+    // Rebuilds a PortableEnv rooted at the tree that CONTAINS the given install dir, mirroring
+    // FakeEnv's layout (install dirs from MakeApplyRig live under <root>\PortableApps\NexusApp).
+    private static PortableEnv FakeEnvFor(string install)
+    {
+        var root = Path.GetDirectoryName(Path.GetDirectoryName(install))!;
+        return new PortableEnv(
+            Path.Combine(root, "Temp"), Path.Combine(root, "Program Files"),
+            Path.Combine(root, "Program Files (x86)"), Path.Combine(root, "Windows"),
+            Path.Combine(root, "LocalAppData"), Path.Combine(root, "AppData", "NexusApp"));
+    }
+
+    [Fact]
+    public void Apply_StaleOldFile_IsClearedAndSwapCompletes()
+    {
+        var (up, install, _, _, zip, hash) = MakeApplyRig();
+        File.WriteAllText(Path.Combine(install, "NexusApp.exe.old"), "stale from a previous failed swap");
+        var result = up.Apply(zip, hash, new Version(6, 9, 0), "6.8.1");
+        Assert.Equal(PortableApplyOutcome.Completed, result.Outcome);
+        Assert.Equal("old exe", File.ReadAllText(Path.Combine(install, "NexusApp.exe.old")));   // the REAL previous exe, not the stale file
+    }
 }

--- a/NexusApp.Tests/SettingsAtomicSaveTests.cs
+++ b/NexusApp.Tests/SettingsAtomicSaveTests.cs
@@ -1,0 +1,55 @@
+using NexusApp.Services;
+using Xunit;
+
+namespace NexusApp.Tests;
+
+// Pins the write-temp-then-rename contract of SettingsService.Save against a temp
+// settings file, so it runs headless and never touches the real user profile. A
+// leftover .tmp would mean the rename never completed and a reader could see a
+// half-written settings.json.
+public class SettingsAtomicSaveTests : IDisposable
+{
+    private readonly List<string> _tempDirs = new();
+
+    public void Dispose()
+    {
+        foreach (var d in _tempDirs)
+        {
+            try { if (Directory.Exists(d)) Directory.Delete(d, recursive: true); }
+            catch { /* best effort */ }
+        }
+    }
+
+    private string TempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "nexus-settings-test-" + Path.GetRandomFileName());
+        _tempDirs.Add(dir);
+        return dir;
+    }
+
+    [Fact]
+    public void Save_LeavesNoTempFileAndRoundTrips()
+    {
+        var path = Path.Combine(TempDir(), "settings.json");
+        var s = new SettingsService(path);
+        s.Current.LastSeenVersion = "6.9.0";
+        s.Save();
+        Assert.False(File.Exists(path + ".tmp"));   // the write-temp-then-rename must finish the rename
+        Assert.Equal("6.9.0", new SettingsService(path).Current.LastSeenVersion);
+    }
+
+    [Fact]
+    public void Save_ReplacesExistingFileAndStaleTemp()
+    {
+        var path = Path.Combine(TempDir(), "settings.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path + ".tmp", "{ stale garbage from a crashed save");
+        var s = new SettingsService(path);
+        s.Current.LastSeenVersion = "1.0.0";
+        s.Save();
+        s.Current.LastSeenVersion = "2.0.0";
+        s.Save();
+        Assert.False(File.Exists(path + ".tmp"));
+        Assert.Equal("2.0.0", new SettingsService(path).Current.LastSeenVersion);
+    }
+}

--- a/NexusApp.Tests/SwapJournalTests.cs
+++ b/NexusApp.Tests/SwapJournalTests.cs
@@ -46,11 +46,18 @@ public class SwapJournalTests : IDisposable
         Assert.False(back.Ops[0].NewPlaced);
     }
 
+    // Both versions must parse or TryLoad refuses the file, so every fixture that expects a
+    // readable journal back carries them.
+    private static SwapJournal Fixture() => new()
+    {
+        AttemptedVersion = "6.9.0", PreviousVersion = "6.8.1", InstallDir = @"C:\Somewhere\NexusApp",
+    };
+
     [Fact]
     public void Save_LeavesNoTempAndSurvivesOverwrite()
     {
         var path = Path.Combine(TempDir(), SwapJournal.FileName);
-        var j = new SwapJournal { InstallDir = @"C:\Somewhere\NexusApp" };
+        var j = Fixture();
         j.Save(path);
         j.Ops.Add(new SwapOp { Rel = "NexusApp.exe" });
         j.Save(path);
@@ -63,7 +70,7 @@ public class SwapJournalTests : IDisposable
     {
         var path = Path.Combine(TempDir(), SwapJournal.FileName);
         File.WriteAllText(path + ".tmp", "{ truncated by a crash");
-        new SwapJournal { InstallDir = @"C:\Somewhere\NexusApp" }.Save(path);
+        Fixture().Save(path);
         Assert.False(File.Exists(path + ".tmp"));
         Assert.NotNull(SwapJournal.TryLoad(path));
     }
@@ -72,7 +79,32 @@ public class SwapJournalTests : IDisposable
     public void TryLoad_RejectsNullOpElement()
     {
         var path = Path.Combine(TempDir(), SwapJournal.FileName);
-        File.WriteAllText(path, """{ "Schema": 1, "Status": "InProgress", "InstallDir": "C:\\x", "Ops": [null] }""");
+        File.WriteAllText(path, """{ "Schema": 1, "Status": "InProgress", "AttemptedVersion": "6.9.0", "PreviousVersion": "6.8.1", "InstallDir": "C:\\x", "Ops": [null] }""");
+        Assert.Null(SwapJournal.TryLoad(path));
+    }
+
+    [Theory]
+    // Both versions flow into UpdateNotice.SwapFailedBody verbatim: a journal that cannot
+    // supply real ones is refused rather than rendered.
+    [InlineData("""{ "Schema": 1, "Status": "InProgress", "AttemptedVersion": "6.9.0; DROP", "PreviousVersion": "6.8.1", "InstallDir": "C:\\x" }""")]
+    [InlineData("""{ "Schema": 1, "Status": "InProgress", "AttemptedVersion": "6.9.0", "PreviousVersion": "not a version", "InstallDir": "C:\\x" }""")]
+    [InlineData("""{ "Schema": 1, "Status": "InProgress", "AttemptedVersion": "", "PreviousVersion": "", "InstallDir": "C:\\x" }""")]
+    [InlineData("""{ "Schema": 1, "Status": "InProgress", "InstallDir": "C:\\x" }""")]   // both missing
+    public void TryLoad_RejectsUnparseableVersions(string content)
+    {
+        var path = Path.Combine(TempDir(), SwapJournal.FileName);
+        File.WriteAllText(path, content);
+        Assert.Null(SwapJournal.TryLoad(path));
+    }
+
+    [Fact]
+    public void TryLoad_RejectsAnOversizedFile()
+    {
+        // Refused on the file length, before the bytes are read into memory.
+        var path = Path.Combine(TempDir(), SwapJournal.FileName);
+        Fixture().Save(path);
+        Assert.NotNull(SwapJournal.TryLoad(path));
+        File.WriteAllText(path, File.ReadAllText(path) + new string(' ', SwapJournal.MaxJournalBytes));
         Assert.Null(SwapJournal.TryLoad(path));
     }
 

--- a/NexusApp.Tests/SwapJournalTests.cs
+++ b/NexusApp.Tests/SwapJournalTests.cs
@@ -1,0 +1,114 @@
+using NexusApp.Services;
+using Xunit;
+
+namespace NexusApp.Tests;
+
+public class SwapJournalTests : IDisposable
+{
+    private readonly List<string> _tempDirs = new();
+
+    public void Dispose()
+    {
+        foreach (var d in _tempDirs)
+        {
+            try { if (Directory.Exists(d)) Directory.Delete(d, recursive: true); }
+            catch { /* best effort */ }
+        }
+    }
+
+    private string TempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "nexus-journal-test-" + Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        _tempDirs.Add(dir);
+        return dir;
+    }
+
+    [Fact]
+    public void SaveThenTryLoad_RoundTrips()
+    {
+        var path = Path.Combine(TempDir(), SwapJournal.FileName);
+        var j = new SwapJournal
+        {
+            Status = SwapJournal.StatusInProgress,
+            AttemptedVersion = "6.9.0",
+            PreviousVersion = "6.8.1",
+            InstallDir = @"C:\Somewhere\NexusApp",
+            Ops = { new SwapOp { Rel = "NexusApp.exe", OldMoved = true } },
+        };
+        j.Save(path);
+        var back = SwapJournal.TryLoad(path);
+        Assert.NotNull(back);
+        Assert.Equal("6.9.0", back!.AttemptedVersion);
+        Assert.Equal("6.8.1", back.PreviousVersion);
+        Assert.Single(back.Ops);
+        Assert.True(back.Ops[0].OldMoved);
+        Assert.False(back.Ops[0].NewPlaced);
+    }
+
+    [Fact]
+    public void Save_LeavesNoTempAndSurvivesOverwrite()
+    {
+        var path = Path.Combine(TempDir(), SwapJournal.FileName);
+        var j = new SwapJournal { InstallDir = @"C:\Somewhere\NexusApp" };
+        j.Save(path);
+        j.Ops.Add(new SwapOp { Rel = "NexusApp.exe" });
+        j.Save(path);
+        Assert.False(File.Exists(path + ".tmp"));
+        Assert.Single(SwapJournal.TryLoad(path)!.Ops);
+    }
+
+    [Fact]
+    public void Save_ReplacesAStaleTempFromACrashedWrite()
+    {
+        var path = Path.Combine(TempDir(), SwapJournal.FileName);
+        File.WriteAllText(path + ".tmp", "{ truncated by a crash");
+        new SwapJournal { InstallDir = @"C:\Somewhere\NexusApp" }.Save(path);
+        Assert.False(File.Exists(path + ".tmp"));
+        Assert.NotNull(SwapJournal.TryLoad(path));
+    }
+
+    [Fact]
+    public void TryLoad_RejectsNullOpElement()
+    {
+        var path = Path.Combine(TempDir(), SwapJournal.FileName);
+        File.WriteAllText(path, """{ "Schema": 1, "Status": "InProgress", "InstallDir": "C:\\x", "Ops": [null] }""");
+        Assert.Null(SwapJournal.TryLoad(path));
+    }
+
+    [Fact]
+    public void TryLoad_MissingFile_ReturnsNull() =>
+        Assert.Null(SwapJournal.TryLoad(Path.Combine(TempDir(), "nope.json")));
+
+    [Theory]
+    [InlineData("{ not json")]
+    [InlineData("null")]
+    [InlineData("{}")]                                                       // defaults leave InstallDir empty
+    [InlineData("""{ "Schema": 2, "Status": "InProgress", "InstallDir": "C:\\x" }""")]   // future schema
+    [InlineData("""{ "Schema": 1, "Status": "Sideways", "InstallDir": "C:\\x" }""")]     // unknown status
+    [InlineData("""{ "Schema": 1, "Status": "InProgress", "InstallDir": "relative\\dir" }""")]
+    public void TryLoad_RejectsHostileOrForeignContent(string content)
+    {
+        var path = Path.Combine(TempDir(), SwapJournal.FileName);
+        File.WriteAllText(path, content);
+        Assert.Null(SwapJournal.TryLoad(path));
+    }
+
+    [Theory]
+    [InlineData("NexusApp.exe", true)]
+    [InlineData(@"Web\cargo\index.html", true)]
+    [InlineData("Web/cargo/index.html", true)]
+    [InlineData("", false)]
+    [InlineData("..", false)]
+    [InlineData(@"..\outside.txt", false)]
+    [InlineData(@"Web\..\..\outside.txt", false)]
+    [InlineData(@"C:\rooted.txt", false)]
+    [InlineData(@"\rooted.txt", false)]
+    [InlineData("name:stream.txt", false)]   // NTFS alternate data stream
+    [InlineData(@"Web\.\file.txt", false)]
+    public void IsSafeRel_Matrix(string rel, bool expected)
+    {
+        var installDir = TempDir();
+        Assert.Equal(expected, SwapJournal.IsSafeRel(installDir, rel));
+    }
+}

--- a/NexusApp.Tests/UpdateNoticeTests.cs
+++ b/NexusApp.Tests/UpdateNoticeTests.cs
@@ -51,6 +51,8 @@ public class UpdateNoticeTests
     [InlineData("Downloading")]
     [InlineData("Verifying")]
     [InlineData("ReadyToInstall")]
+    [InlineData("Installing")]
+    [InlineData("ManualHandoff")]
     public void StatusLine_AvailableStates_NameTheVersion(string state) =>
         Assert.Equal("Nexus 9.9.9 is available", UpdateNotice.StatusLine(state, new Version(9, 9, 9), null, false));
 
@@ -72,6 +74,13 @@ public class UpdateNoticeTests
             UpdateNotice.ReadyBodyInstaller(new Version(6, 7, 0)),
             UpdateNotice.ReadyBodyPortable(new Version(6, 7, 0)),
             UpdateNotice.PostUpdateBody("6.7.0"),
+            UpdateNotice.InstallConfirmBodyPortable,
+            UpdateNotice.PrepareFailedBody,
+            UpdateNotice.PreparingBody(new Version(6, 9, 0)),
+            UpdateNotice.ReadyBodyPortableManual(new Version(6, 9, 0)),
+            UpdateNotice.UnpackingBody(new Version(6, 9, 0)),
+            UpdateNotice.ManualHandoffBody(new Version(6, 9, 0)),
+            UpdateNotice.SwapFailedBody("6.9.0", "6.8.1"),
         };
         foreach (var s in all)
         {
@@ -104,5 +113,30 @@ public class UpdateNoticeTests
             Assert.NotNull(again.Current.LastUpdateCheckUtc);
         }
         finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void ReadyBodyPortable_MatchesInstallerBody() =>
+        // Installer parity: the portable user should not need distribution vocabulary.
+        Assert.Equal(UpdateNotice.ReadyBodyInstaller(new Version(6, 9, 0)),
+                     UpdateNotice.ReadyBodyPortable(new Version(6, 9, 0)));
+
+    [Fact]
+    public void PortableSwapBodies_PinExactCopy()
+    {
+        Assert.Equal("Nexus will close for a moment and reopen as the new version. Your settings, work orders, and blueprints are kept.",
+            UpdateNotice.InstallConfirmBodyPortable);
+        Assert.Equal("Preparing Nexus 6.9.0. Nexus will close and reopen in a moment.",
+            UpdateNotice.PreparingBody(new Version(6, 9, 0)));
+        Assert.Equal("Nexus 6.9.0 is downloaded and verified. Nexus cannot replace its own files from this location, so this update finishes with one quick copy.",
+            UpdateNotice.ReadyBodyPortableManual(new Version(6, 9, 0)));
+        Assert.Equal("Unpacking Nexus 6.9.0.",
+            UpdateNotice.UnpackingBody(new Version(6, 9, 0)));
+        Assert.Equal("Two folders are open: the new Nexus 6.9.0 and your current Nexus. Close Nexus, then copy everything from the new folder into the current one, replacing files when asked.",
+            UpdateNotice.ManualHandoffBody(new Version(6, 9, 0)));
+        Assert.Equal("Couldn't prepare the update. Nothing was changed. Try again, or update manually from Settings > Diagnostics.",
+            UpdateNotice.PrepareFailedBody);
+        Assert.Equal("The update to Nexus 6.9.0 could not finish. Nexus restored the previous version and nothing changed. You are still on Nexus 6.8.1.",
+            UpdateNotice.SwapFailedBody("6.9.0", "6.8.1"));
     }
 }

--- a/NexusApp.Tests/UpdateNoticeTests.cs
+++ b/NexusApp.Tests/UpdateNoticeTests.cs
@@ -76,6 +76,7 @@ public class UpdateNoticeTests
             UpdateNotice.PostUpdateBody("6.7.0"),
             UpdateNotice.InstallConfirmBodyPortable,
             UpdateNotice.PrepareFailedBody,
+            UpdateNotice.RestorePendingBody,
             UpdateNotice.PreparingBody(new Version(6, 9, 0)),
             UpdateNotice.ReadyBodyPortableManual(new Version(6, 9, 0)),
             UpdateNotice.UnpackingBody(new Version(6, 9, 0)),
@@ -136,6 +137,8 @@ public class UpdateNoticeTests
             UpdateNotice.ManualHandoffBody(new Version(6, 9, 0)));
         Assert.Equal("Couldn't prepare the update. Nothing was changed. Try again, or update manually from Settings > Diagnostics.",
             UpdateNotice.PrepareFailedBody);
+        Assert.Equal("The update could not finish. Nexus will finish restoring the previous version the next time it starts. Close Nexus and start it again.",
+            UpdateNotice.RestorePendingBody);
         Assert.Equal("The update to Nexus 6.9.0 could not finish. Nexus restored the previous version and nothing changed. You are still on Nexus 6.8.1.",
             UpdateNotice.SwapFailedBody("6.9.0", "6.8.1"));
     }

--- a/NexusApp.Tests/UpdateServiceTests.cs
+++ b/NexusApp.Tests/UpdateServiceTests.cs
@@ -70,6 +70,25 @@ public class UpdateServiceTests : IDisposable
         }
     }
 
+    private sealed class FakeSwapper : IPortableSwapper
+    {
+        public PortablePreflight PreflightResult { get; set; } = new(true, "");
+        public PortableApplyResult ApplyResult { get; set; } = new(PortableApplyOutcome.Completed, "");
+        public bool UnpackResult { get; set; } = true;
+        public Exception? PreflightThrows { get; set; }
+        public int PreflightCalls; public int ApplyCalls; public int UnpackCalls;
+        public PortablePreflight Preflight(long zipBytes)
+        {
+            PreflightCalls++;
+            if (PreflightThrows is not null) throw PreflightThrows;
+            return PreflightResult;
+        }
+        public PortableApplyResult Apply(string zipPath, string expectedSha256, Version version, string currentVersion)
+        { ApplyCalls++; return ApplyResult; }
+        public bool UnpackForManual(string zipPath, string expectedSha256, Version version)
+        { UnpackCalls++; return UnpackResult; }
+    }
+
     private static readonly (string priv, string pub) Key = NewKeyPair();
 
     private static (string, string) NewKeyPair()
@@ -104,7 +123,8 @@ public class UpdateServiceTests : IDisposable
         var settings = new SettingsService(Path.Combine(dir, "settings.json"));
         var svc = new UpdateService(settings, t,
             (m, s) => UpdateVerifier.VerifySignature(m, s, Key.pub),
-            () => distribution, currentVersion, Path.Combine(dir, "updates"), demo);
+            () => distribution, currentVersion, Path.Combine(dir, "updates"), demo,
+            swapper: new FakeSwapper(), purgeGuard: () => false);
         return (svc, t, settings, dir);
     }
 
@@ -121,8 +141,25 @@ public class UpdateServiceTests : IDisposable
         var svc = new UpdateService(settings, t,
             (m, s) => UpdateVerifier.VerifySignature(m, s, Key.pub),
             () => distribution, currentVersion, Path.Combine(dir, "updates"), demo,
-            p => { started.Add(p); return true; });
+            p => { started.Add(p); return true; }, swapper: new FakeSwapper(), purgeGuard: () => false);
         return (svc, t, settings, dir, started);
+    }
+
+    // Make2 plus the portable swapper seam and a deterministic purge guard.
+    private (UpdateService svc, FakeTransport t, SettingsService settings, string dir, FakeSwapper swapper) Make3(
+        string currentVersion = "6.6.2", string distribution = "Portable", bool demo = false,
+        Func<bool>? purgeGuard = null)
+    {
+        var t = new FakeTransport();
+        var dir = Path.Combine(Path.GetTempPath(), "nexus-updates-test-" + Path.GetRandomFileName());
+        _tempDirs.Add(dir);
+        var settings = new SettingsService(Path.Combine(dir, "settings.json"));
+        var swapper = new FakeSwapper();
+        var svc = new UpdateService(settings, t,
+            (m, s) => UpdateVerifier.VerifySignature(m, s, Key.pub),
+            () => distribution, currentVersion, Path.Combine(dir, "updates"), demo,
+            p => true, swapper, purgeGuard ?? (() => false), () => @"C:\fake\NexusApp.exe");
+        return (svc, t, settings, dir, swapper);
     }
 
     // Exactly what SettingsPage feeds the Updates status row, so a test reads the line the user
@@ -565,5 +602,179 @@ public class UpdateServiceTests : IDisposable
         File.WriteAllText(Path.Combine(updates, "9.9.9", "old.partial"), "junk");
         svc.PurgeStaleDownloads();
         Assert.False(Directory.Exists(updates));
+    }
+
+    // ---- Portable self-swap state machine ----
+
+    // Both assets are published and served so the helper reaches ReadyToInstall for EITHER
+    // distribution: the installer variant exists to prove ApplyPortableAsync refuses from a
+    // healthy ReadyToInstall, which a 404'd download would hide behind a Failed state.
+    private async Task<(UpdateService svc, FakeSwapper swapper)> ReadyPortable(
+        string distribution = "Portable", Func<bool>? purgeGuard = null)
+    {
+        var (svc, t, _, _, swapper) = Make3(distribution: distribution, purgeGuard: purgeGuard);
+        var payload = Encoding.UTF8.GetBytes("zip bytes");
+        var setup = Encoding.UTF8.GetBytes("setup bytes");
+        Publish(t, UpdateManifestTests.ValidJson(version: "9.9.9",
+            setupHash: HashOf(setup), setupSize: setup.Length,
+            portableHash: HashOf(payload), portableSize: payload.Length));
+        t.Files[UpdateService.AssetUrl(new Version(9, 9, 9), "NexusApp_portable.zip")] = payload;
+        t.Files[UpdateService.AssetUrl(new Version(9, 9, 9), "Nexus_Setup.exe")] = setup;
+        await svc.CheckAsync(manual: true);
+        await svc.DownloadAsync();
+        return (svc, swapper);
+    }
+
+    [Fact]
+    public async Task Download_Portable_EvaluatesPreflightAndPublishesAvailability()
+    {
+        var (svc, swapper) = await ReadyPortable();
+        Assert.Equal(UpdateState.ReadyToInstall, svc.State);
+        Assert.Equal(1, swapper.PreflightCalls);
+        Assert.True(svc.PortableSwapAvailable);
+        Assert.Null(svc.PortableSwapUnavailableReason);
+    }
+
+    [Fact]
+    public async Task Download_PortablePreflightFails_OffersManualWithReason()
+    {
+        var (svc, t, _, _, swapper) = Make3();
+        swapper.PreflightResult = new PortablePreflight(false, "the app file has been renamed");
+        var payload = Encoding.UTF8.GetBytes("zip bytes");
+        Publish(t, UpdateManifestTests.ValidJson(version: "9.9.9", portableHash: HashOf(payload), portableSize: payload.Length));
+        t.Files[UpdateService.AssetUrl(new Version(9, 9, 9), "NexusApp_portable.zip")] = payload;
+        await svc.CheckAsync(manual: true);
+        await svc.DownloadAsync();
+        Assert.Equal(UpdateState.ReadyToInstall, svc.State);
+        Assert.False(svc.PortableSwapAvailable);
+        Assert.Equal("the app file has been renamed", svc.PortableSwapUnavailableReason);
+    }
+
+    [Fact]
+    public async Task Download_Installer_NeverTouchesThePreflight()
+    {
+        var (svc, t, _, _, swapper) = Make3(distribution: "Installer");
+        var payload = Encoding.UTF8.GetBytes("setup bytes");
+        Publish(t, UpdateManifestTests.ValidJson(version: "9.9.9", setupHash: HashOf(payload), setupSize: payload.Length));
+        t.Files[UpdateService.AssetUrl(new Version(9, 9, 9), "Nexus_Setup.exe")] = payload;
+        await svc.CheckAsync(manual: true);
+        await svc.DownloadAsync();
+        Assert.Equal(0, swapper.PreflightCalls);
+        Assert.False(svc.PortableSwapAvailable);
+    }
+
+    [Fact]
+    public async Task Download_PreflightThrows_StillLandsReadyWithManualFlow()
+    {
+        // The one place an engine exception could strand a verified download short of
+        // ReadyToInstall: it must land in the manual flow instead, with the cause logged.
+        var (svc, t, _, _, swapper) = Make3();
+        swapper.PreflightThrows = new InvalidOperationException("boom");
+        var payload = Encoding.UTF8.GetBytes("zip bytes");
+        Publish(t, UpdateManifestTests.ValidJson(version: "9.9.9", portableHash: HashOf(payload), portableSize: payload.Length));
+        t.Files[UpdateService.AssetUrl(new Version(9, 9, 9), "NexusApp_portable.zip")] = payload;
+        await svc.CheckAsync(manual: true);
+        await svc.DownloadAsync();
+        Assert.Equal(UpdateState.ReadyToInstall, svc.State);
+        Assert.False(svc.PortableSwapAvailable);
+        Assert.NotNull(svc.PortableSwapUnavailableReason);
+    }
+
+    [Fact]
+    public async Task ApplyPortable_HappyPath_LandsInInstallingWithRelaunchPending()
+    {
+        var (svc, swapper) = await ReadyPortable();
+        Assert.True(await svc.ApplyPortableAsync());
+        Assert.Equal(1, swapper.ApplyCalls);
+        Assert.Equal(UpdateState.Installing, svc.State);
+        Assert.True(svc.PortableApplyInProgress);
+        Assert.Equal(@"C:\fake\NexusApp.exe", svc.PendingRelaunchPath);
+        Assert.Equal("Nexus 9.9.9 is available", StatusOf(svc));   // Installing keeps the available line
+    }
+
+    [Fact]
+    public async Task ApplyPortable_Failure_ReturnsToReadyWithTheReason()
+    {
+        var (svc, swapper) = await ReadyPortable();
+        swapper.ApplyResult = new PortableApplyResult(PortableApplyOutcome.FailedRolledBack, "e_sqlite3.dll is held open by another program");
+        Assert.False(await svc.ApplyPortableAsync());
+        Assert.Equal(UpdateState.ReadyToInstall, svc.State);
+        Assert.False(svc.PortableApplyInProgress);
+        Assert.Null(svc.PendingRelaunchPath);
+        Assert.Equal("e_sqlite3.dll is held open by another program", svc.LastPortableApplyFailure);
+        // A later successful attempt must clear the note.
+        swapper.ApplyResult = new PortableApplyResult(PortableApplyOutcome.Completed, "");
+        Assert.True(await svc.ApplyPortableAsync());
+        Assert.Null(svc.LastPortableApplyFailure);
+    }
+
+    [Fact]
+    public async Task ApplyPortable_InstallerDistribution_Refuses()
+    {
+        var (svc, swapper) = await ReadyPortable(distribution: "Installer");
+        Assert.False(await svc.ApplyPortableAsync());
+        Assert.Equal(0, swapper.ApplyCalls);
+        Assert.Equal(UpdateState.ReadyToInstall, svc.State);
+    }
+
+    [Fact]
+    public async Task ApplyPortable_WrongState_Refuses()
+    {
+        var (svc, _, _, _, swapper) = Make3();
+        Assert.False(await svc.ApplyPortableAsync());   // Idle: nothing downloaded
+        Assert.Equal(0, swapper.ApplyCalls);
+    }
+
+    [Fact]
+    public async Task ApplyPortable_Demo_IsInert()
+    {
+        var (svc, _, _, _, swapper) = Make3(demo: true);
+        Assert.False(await svc.ApplyPortableAsync());
+        Assert.Equal(0, swapper.ApplyCalls);
+    }
+
+    [Fact]
+    public async Task UnpackForManual_Success_LandsInManualHandoff()
+    {
+        var (svc, swapper) = await ReadyPortable();
+        await svc.UnpackForManualAsync();
+        Assert.Equal(1, swapper.UnpackCalls);
+        Assert.Equal(UpdateState.ManualHandoff, svc.State);
+        Assert.Equal("Nexus 9.9.9 is available", StatusOf(svc));
+    }
+
+    [Fact]
+    public async Task UnpackForManual_Failure_ReturnsToReadyWithNote()
+    {
+        var (svc, swapper) = await ReadyPortable();
+        swapper.UnpackResult = false;
+        await svc.UnpackForManualAsync();
+        Assert.Equal(UpdateState.ReadyToInstall, svc.State);
+        Assert.NotNull(svc.LastPortableApplyFailure);
+    }
+
+    [Fact]
+    public async Task PreferManualUpdate_ForcesTheManualFlow()
+    {
+        var (svc, t, _, _, swapper) = Make3();
+        svc.PreferManualUpdate = true;
+        var payload = Encoding.UTF8.GetBytes("zip bytes");
+        Publish(t, UpdateManifestTests.ValidJson(version: "9.9.9", portableHash: HashOf(payload), portableSize: payload.Length));
+        t.Files[UpdateService.AssetUrl(new Version(9, 9, 9), "NexusApp_portable.zip")] = payload;
+        await svc.CheckAsync(manual: true);
+        await svc.DownloadAsync();
+        Assert.False(svc.PortableSwapAvailable);
+        Assert.Equal(0, swapper.PreflightCalls);   // the choice is honored without probing
+    }
+
+    [Fact]
+    public void PurgeStaleDownloads_SkipsWhileAJournalExists()
+    {
+        var (svc, _, _, dir, _) = Make3(purgeGuard: () => true);
+        var updates = Path.Combine(dir, "updates");
+        Directory.CreateDirectory(Path.Combine(updates, "9.9.9"));
+        File.WriteAllText(Path.Combine(updates, "9.9.9", "NexusApp_portable.zip"), "the recovery artifact");
+        svc.PurgeStaleDownloads();
+        Assert.True(File.Exists(Path.Combine(updates, "9.9.9", "NexusApp_portable.zip")));
     }
 }

--- a/NexusApp.Tests/UpdateServiceTests.cs
+++ b/NexusApp.Tests/UpdateServiceTests.cs
@@ -664,6 +664,23 @@ public class UpdateServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task Download_PendingJournal_OffersManualWithoutProbing()
+    {
+        // A pending journal means Apply will refuse anyway: the strip must route to the guided
+        // manual flow rather than an Install button whose Try again cannot work until restart.
+        var (svc, t, _, _, swapper) = Make3(purgeGuard: () => true);
+        var payload = Encoding.UTF8.GetBytes("zip bytes");
+        Publish(t, UpdateManifestTests.ValidJson(version: "9.9.9", portableHash: HashOf(payload), portableSize: payload.Length));
+        t.Files[UpdateService.AssetUrl(new Version(9, 9, 9), "NexusApp_portable.zip")] = payload;
+        await svc.CheckAsync(manual: true);
+        await svc.DownloadAsync();
+        Assert.Equal(UpdateState.ReadyToInstall, svc.State);
+        Assert.False(svc.PortableSwapAvailable);
+        Assert.Contains("previous update", svc.PortableSwapUnavailableReason);
+        Assert.Equal(0, swapper.PreflightCalls);
+    }
+
+    [Fact]
     public async Task Download_PreflightThrows_StillLandsReadyWithManualFlow()
     {
         // The one place an engine exception could strand a verified download short of
@@ -709,6 +726,24 @@ public class UpdateServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task ApplyPortable_RollbackIncomplete_FlagsTheRestoreAsPending()
+    {
+        // The stuck-rollback state drives different copy and drops the Try again button: the
+        // previous version can only be put back by the next start's recovery.
+        var (svc, swapper) = await ReadyPortable();
+        swapper.ApplyResult = new PortableApplyResult(PortableApplyOutcome.FailedRollbackIncomplete,
+            "e_sqlite3.dll changed between unpack and install");
+        Assert.False(await svc.ApplyPortableAsync());
+        Assert.Equal(UpdateState.ReadyToInstall, svc.State);
+        Assert.True(svc.LastApplyLeftRestorePending);
+        Assert.NotNull(svc.LastPortableApplyFailure);
+        // An ordinary rollback is not the pending state, and a later run clears the flag.
+        swapper.ApplyResult = new PortableApplyResult(PortableApplyOutcome.FailedRolledBack, "held open by another program");
+        Assert.False(await svc.ApplyPortableAsync());
+        Assert.False(svc.LastApplyLeftRestorePending);
+    }
+
+    [Fact]
     public async Task ApplyPortable_InstallerDistribution_Refuses()
     {
         var (svc, swapper) = await ReadyPortable(distribution: "Installer");
@@ -750,6 +785,22 @@ public class UpdateServiceTests : IDisposable
         swapper.UnpackResult = false;
         await svc.UnpackForManualAsync();
         Assert.Equal(UpdateState.ReadyToInstall, svc.State);
+        Assert.NotNull(svc.LastPortableApplyFailure);
+    }
+
+    [Fact]
+    public async Task UnpackForManual_AfterAStuckRollback_ClearsTheRestorePendingFlag()
+    {
+        // The manual unpack is its own attempt: its failure must regain the Try again
+        // affordance instead of keeping the earlier swap's restart-to-restore copy.
+        var (svc, swapper) = await ReadyPortable();
+        swapper.ApplyResult = new PortableApplyResult(PortableApplyOutcome.FailedRollbackIncomplete, "rollback incomplete at e_sqlite3.dll");
+        Assert.False(await svc.ApplyPortableAsync());
+        Assert.True(svc.LastApplyLeftRestorePending);
+        swapper.UnpackResult = false;
+        await svc.UnpackForManualAsync();
+        Assert.Equal(UpdateState.ReadyToInstall, svc.State);
+        Assert.False(svc.LastApplyLeftRestorePending);
         Assert.NotNull(svc.LastPortableApplyFailure);
     }
 

--- a/NexusApp/App.xaml.cs
+++ b/NexusApp/App.xaml.cs
@@ -36,6 +36,10 @@ public partial class App : Application
     // session overwrites LastSeenVersion. Drives the one-time "updated to" strip.
     public static string? PreviousSessionVersion { get; private set; }
 
+    // Set when startup recovery restored the previous version after a crashed portable swap;
+    // drives the one-time swap-failed strip on Operations. Null when nothing happened.
+    public static string? SwapFailedAttemptedVersion { get; private set; }
+
     // Diagnostic-only: logs which process takes the OS foreground (for the mid-session tab-out reports).
     private static ForegroundMonitor? _foreground;
 
@@ -192,6 +196,10 @@ public partial class App : Application
         // the strictly-greater rule, so manual downgrades stay quiet; every start records the
         // running version so the next upgrade can announce itself.
         Update = new UpdateService(Settings);
+        // Swap recovery MUST run before the purge: the journal decides whether updates\
+        // still holds the crash-recovery zip, and the purge itself skips while one exists.
+        var swapRecovery = PortableUpdater.RecoverAtStartup();
+        if (swapRecovery.ShowSwapFailedNotice) SwapFailedAttemptedVersion = swapRecovery.AttemptedVersion;
         Update.PurgeStaleDownloads();
         PreviousSessionVersion = Settings.Current.LastSeenVersion;
         if (Settings.Current.LastSeenVersion != AppInfo.Version)
@@ -363,6 +371,28 @@ public partial class App : Application
         GameLog?.Dispose();
         Network?.Dispose();
         Data?.Dispose();
+        // Portable self-swap handoff: spawn the NEW exe as the very LAST action, after every
+        // settings and database write above has finished, so the two instances never overlap
+        // on the same profile. Log BEFORE spawning (CrashGuard pattern): if Start throws, the
+        // log must still explain what happened. Spawn success is the only health check; the
+        // .old set plus the journal are the recovery story if the child dies.
+        if (Update is { PendingRelaunchPath: { Length: > 0 } relaunch })
+        {
+            Logger.Info("[UPDATE] relaunching as the new version");
+            try
+            {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(relaunch)
+                {
+                    UseShellExecute = false,
+                    // A shortcut's "Start in" can point anywhere; anchor the child explicitly.
+                    WorkingDirectory = System.IO.Path.GetDirectoryName(relaunch)!,
+                });
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("[UPDATE] couldn't relaunch after the swap; start Nexus manually from its folder", ex);
+            }
+        }
         base.OnExit(e);
     }
 }

--- a/NexusApp/README.txt
+++ b/NexusApp/README.txt
@@ -41,8 +41,10 @@ GETTING STARTED
 4. Open the extracted folder.
 5. Double-click "NexusApp.exe" to start NexusApp.
 
-NexusApp needs no installation. NexusApp needs no internet connection.
-NexusApp stores your settings and work orders on your PC.
+NexusApp needs no installation. NexusApp needs no internet connection
+for its features. NexusApp stores your settings and work orders on
+your PC. NexusApp can check for updates, but only when you allow it.
+See the UPDATES section below.
 
 
 WINDOWS SMARTSCREEN WARNING
@@ -70,6 +72,32 @@ WINDOWS SMARTSCREEN WARNING
   security.microsoft.com. You can also add an exclusion for the
   NexusApp folder in Windows Security > Virus & threat protection >
   Exclusions.
+
+
+UPDATES
+-------
+
+  Update checks are off until you turn them on. NexusApp asks you once
+  when it starts. You can change your choice at any time in
+  Settings > Diagnostics.
+
+  When a new version is available, NexusApp shows a notice on the
+  OPERATIONS page. Each step asks before it acts:
+
+  1. Click "Download". NexusApp downloads the new version and verifies
+     it against a signed manifest.
+  2. Click "Install update". NexusApp verifies the files again,
+     replaces its own files, and restarts as the new version.
+
+  Your settings, work orders, and blueprints are kept.
+
+  Some locations do not let NexusApp replace its own files (for
+  example, a protected folder or a network drive). NexusApp then
+  unpacks the update and opens the new folder and your current folder.
+  You copy the new files over the old ones.
+
+  If an update stops before it completes, NexusApp puts the previous
+  version back the next time it starts.
 
 
 FIRST TIME SETUP

--- a/NexusApp/Services/PortableUpdater.cs
+++ b/NexusApp/Services/PortableUpdater.cs
@@ -38,6 +38,10 @@ internal sealed record PortableEnv(
         AppPaths.Root);
 }
 
+// What one verified extraction produced: every payload file's SHA-256 keyed by its backslash
+// path relative to the payload root, the actual decompressed byte count, and that root.
+internal sealed record ExtractResult(Dictionary<string, string> FileHashes, long TotalBytes, string PayloadRoot);
+
 // The portable self-swap engine: the running, already-verified app replaces its own files
 // with journaled same-volume renames (the Syncthing/yt-dlp pattern) and the new exe is
 // spawned by App.OnExit as the process's last action. Windows permits RENAMING a running
@@ -197,6 +201,75 @@ public sealed class PortableUpdater : IPortableSwapper
         if (string.Equals(file, LockFileName, StringComparison.OrdinalIgnoreCase))
             return "lock filename is not allowed in the payload";
         return null;
+    }
+
+    // ---- Same-handle verify and hardened extraction ----
+
+    // Same-handle verify and extract. The zip is opened denying writers AND deleters
+    // (FileShare.Read), hashed against the SIGNED manifest hash on that open stream, rewound,
+    // and extracted from the SAME handle: the bytes hashed and the bytes extracted are
+    // identical, so there is no zip-level TOCTOU window in the user-writable staging dir.
+    // Per-entry SHA-256 is computed DURING extraction and held in memory so the flip phase
+    // can re-verify each staged file immediately before renaming it into place, which chains
+    // every placed byte to the signed manifest without a manifest schema change.
+    internal static ExtractResult VerifyAndExtract(string zipPath, string expectedSha256, string destDir,
+                                                   int maxEntries = MaxZipEntries, long maxBytes = MaxExtractedBytes)
+    {
+        using var fs = new FileStream(zipPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        var zipHash = Convert.ToHexString(SHA256.HashData(fs)).ToLowerInvariant();
+        if (!string.Equals(zipHash, expectedSha256, StringComparison.Ordinal))
+            throw new InvalidOperationException("the downloaded file failed verification at install time");
+        fs.Position = 0;
+
+        // A stale tree from a crashed run must never contribute files to a swap.
+        if (Directory.Exists(destDir)) Directory.Delete(destDir, recursive: true);
+        Directory.CreateDirectory(destDir);
+        var destRoot = Path.GetFullPath(destDir).TrimEnd('\\') + "\\";
+
+        var hashes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        long total = 0;
+        var exeSeen = false;
+        using var zip = new ZipArchive(fs, ZipArchiveMode.Read, leaveOpen: true);
+        if (zip.Entries.Count > maxEntries)
+            throw new InvalidOperationException("the update archive lists too many files");
+        foreach (var entry in zip.Entries)
+        {
+            var issue = NormalizeEntry(entry.FullName, out var rel);
+            if (issue != null)
+                throw new InvalidOperationException($"refused archive entry \"{entry.FullName}\": {issue}");
+            if (rel.Length == 0) continue;   // the top-level folder entry itself
+            var target = Path.GetFullPath(Path.Combine(destRoot, rel));
+            // Defense in depth beside NormalizeEntry (and .NET 8's own refusal): nothing
+            // canonicalizing outside the destination is ever created.
+            if (!target.StartsWith(destRoot, StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException($"refused archive entry \"{entry.FullName}\": escapes the destination");
+            if (entry.FullName.EndsWith('/') || entry.FullName.EndsWith('\\'))
+            {
+                Directory.CreateDirectory(target);
+                continue;
+            }
+            Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+            if (string.Equals(rel, "NexusApp.exe", StringComparison.OrdinalIgnoreCase)) exeSeen = true;
+            using var src = entry.Open();
+            using var dst = new FileStream(target, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+            using var hasher = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+            var buffer = new byte[81920];
+            int read;
+            while ((read = src.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                total += read;
+                // Enforced on ACTUAL decompressed bytes: a zip header's declared sizes are
+                // metadata an accident (or a bomb) can misstate.
+                if (total > maxBytes)
+                    throw new InvalidOperationException("the update archive expands past the size cap");
+                hasher.AppendData(buffer, 0, read);
+                dst.Write(buffer, 0, read);
+            }
+            hashes[rel] = Convert.ToHexString(hasher.GetHashAndReset()).ToLowerInvariant();
+        }
+        if (!exeSeen)
+            throw new InvalidOperationException("the update archive does not contain NexusApp\\NexusApp.exe");
+        return new ExtractResult(hashes, total, destDir);
     }
 
     // Interface members are completed by later tasks; these throw until then so the class

--- a/NexusApp/Services/PortableUpdater.cs
+++ b/NexusApp/Services/PortableUpdater.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Threading;
+
+namespace NexusApp.Services;
+
+public sealed record PortablePreflight(bool Ok, string Reason);
+
+public enum PortableApplyOutcome { Completed, FailedNothingChanged, FailedRolledBack, FailedRollbackIncomplete }
+
+public sealed record PortableApplyResult(PortableApplyOutcome Outcome, string Reason);
+
+// Seam so UpdateService's state machine is testable without a filesystem or a real swap.
+internal interface IPortableSwapper
+{
+    PortablePreflight Preflight(long zipBytes);
+    PortableApplyResult Apply(string zipPath, string expectedSha256, Version version, string currentVersion);
+    bool UnpackForManual(string zipPath, string expectedSha256, Version version);
+}
+
+// The Windows special folders the precondition rules compare against, injectable so the
+// rules are testable on a throwaway tree (the AppPaths.ResolveRoot pattern).
+internal sealed record PortableEnv(
+    string TempPath, string ProgramFiles, string ProgramFilesX86, string WindowsDir,
+    string LocalAppData, string AppDataRoot)
+{
+    public static PortableEnv Real() => new(
+        Path.GetTempPath(),
+        Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+        Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+        Environment.GetFolderPath(Environment.SpecialFolder.Windows),
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        AppPaths.Root);
+}
+
+// The portable self-swap engine: the running, already-verified app replaces its own files
+// with journaled same-volume renames (the Syncthing/yt-dlp pattern) and the new exe is
+// spawned by App.OnExit as the process's last action. Windows permits RENAMING a running
+// exe and its loaded DLLs; it forbids deleting or overwriting them, which is why there is
+// no overwrite branch anywhere in this file.
+public sealed class PortableUpdater : IPortableSwapper
+{
+    public const string StagingDirName = "update-staging";
+    public const string LockFileName = "update.lock";
+    public const string OldSuffix = ".old";
+    internal const int MaxZipEntries = 4096;
+    internal const long MaxExtractedBytes = 600L * 1024 * 1024;
+    internal const long FreeSpaceSlackBytes = 50L * 1024 * 1024;
+
+    private readonly string _installDir;
+    private readonly string? _processPath;
+    private readonly string _updatesDir;
+    private readonly string _journalPath;
+    private readonly Func<string> _distribution;
+    private readonly PortableEnv _env;
+    private readonly int[] _retryDelaysMs;
+    private readonly Func<int> _nexusProcessCount;
+    private readonly Action<string> _openFolder;
+
+    // Test hook: fires per file after the staging copy, before that file's re-hash, so the
+    // staged-tamper defense is provable. Never set in production.
+    internal Action<string, string>? BeforeFlipHook;
+
+    public PortableUpdater() : this(
+        AppContext.BaseDirectory, Environment.ProcessPath,
+        Path.Combine(AppPaths.Root, "updates"), SwapJournal.DefaultPath,
+        () => NexusApp.AppInfo.Distribution, PortableEnv.Real())
+    { }
+
+    internal PortableUpdater(string installDir, string? processPath, string updatesDir, string journalPath,
+                             Func<string> distribution, PortableEnv env,
+                             int[]? retryDelaysMs = null, Func<int>? nexusProcessCount = null,
+                             Action<string>? openFolder = null)
+    {
+        _installDir = Path.GetFullPath(installDir).TrimEnd('\\');
+        _processPath = processPath;
+        _updatesDir = updatesDir;
+        _journalPath = journalPath;
+        _distribution = distribution;
+        _env = env;
+        _retryDelaysMs = retryDelaysMs ?? new[] { 250, 500, 1000, 2000, 4000, 8000 };
+        _nexusProcessCount = nexusProcessCount ?? CountOwnProcesses;
+        _openFolder = openFolder ?? OpenInExplorer;
+    }
+
+    // Name-based enumeration with immediate Dispose (the ForegroundMonitor pattern): never a
+    // handle into anything. On doubt report two: an unknown process landscape fails closed
+    // to the manual flow, never into a concurrent swap.
+    private static int CountOwnProcesses()
+    {
+        try
+        {
+            var procs = Process.GetProcessesByName(Process.GetCurrentProcess().ProcessName);
+            foreach (var p in procs) p.Dispose();
+            return procs.Length;
+        }
+        catch { return 2; }
+    }
+
+    private static void OpenInExplorer(string dir) =>
+        Process.Start(new ProcessStartInfo("explorer.exe", $"\"{dir}\"") { UseShellExecute = true });
+
+    // ---- Pure precondition rules (no filesystem access) ----
+
+    // Path-shape reasons the self-swap must not run here. Every string doubles as the logged
+    // fallback reason, so it is plain English, lowercase start, no trailing period.
+    internal static string? PreflightPathIssue(string? processPath, string baseDirectory, PortableEnv env)
+    {
+        if (string.IsNullOrEmpty(processPath)) return "the running process path is unknown";
+        if (!string.Equals(Path.GetFileName(processPath), "NexusApp.exe", StringComparison.OrdinalIgnoreCase))
+            return "the app file has been renamed";
+        string exeDir, baseDir;
+        try
+        {
+            exeDir = Path.GetFullPath(Path.GetDirectoryName(processPath)!).TrimEnd('\\');
+            baseDir = Path.GetFullPath(baseDirectory).TrimEnd('\\');
+        }
+        catch { return "the install folder path could not be resolved"; }
+        // Environment.ProcessPath is the anchor (single-file publish can point BaseDirectory
+        // at an extraction cache under DOTNET_BUNDLE_EXTRACT_BASE_DIR); disagreement means
+        // the swap would target the wrong directory.
+        if (!string.Equals(exeDir, baseDir, StringComparison.OrdinalIgnoreCase))
+            return "the app is not running from its own folder";
+        if (exeDir.Length > 200) return "the install folder path is too long";
+        if (exeDir.StartsWith(@"\\", StringComparison.Ordinal)) return "the install folder is on a network share";
+        if (IsUnder(exeDir, env.TempPath)) return "the app is running from a temporary folder";
+        if (IsUnder(exeDir, env.AppDataRoot)) return "the app is running from the Nexus data folder";
+        if (IsUnder(exeDir, env.ProgramFiles) || IsUnder(exeDir, env.ProgramFilesX86))
+            return "the install folder is under Program Files";
+        if (IsUnder(exeDir, env.WindowsDir)) return "the install folder is under Windows";
+        var installerDir = Path.Combine(env.LocalAppData, "Nexus").TrimEnd('\\');
+        if (string.Equals(exeDir, installerDir, StringComparison.OrdinalIgnoreCase))
+            return "this is the installed copy of Nexus";
+        return null;
+    }
+
+    private static bool IsUnder(string dir, string root)
+    {
+        if (string.IsNullOrEmpty(root)) return false;
+        string r;
+        try { r = Path.GetFullPath(root).TrimEnd('\\') + "\\"; }
+        catch { return false; }
+        return (dir + "\\").StartsWith(r, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ---- Zip entry hardening ----
+
+    private static readonly HashSet<string> ReservedDeviceNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "CON", "PRN", "AUX", "NUL",
+        "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+        "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+    };
+
+    // Validates one zip entry name and yields its path relative to the mandatory top-level
+    // NexusApp folder ("" for the folder entry itself). Inputs are already whole-zip
+    // hash-verified, so anything unexpected is a packaging accident and gets refused loudly,
+    // the UpdateManifest.Parse philosophy. Returns the rejection reason or null.
+    internal static string? NormalizeEntry(string entryName, out string rel)
+    {
+        rel = "";
+        var name = entryName.Replace('/', '\\');
+        if (name.Length == 0) return "empty entry name";
+        if (name.Contains(':')) return "drive or stream separator in entry name";
+        if (name.StartsWith('\\')) return "rooted entry name";
+        var segs = name.Split('\\');
+        for (int i = 0; i < segs.Length; i++)
+        {
+            var seg = segs[i];
+            if (seg.Length == 0 && i == segs.Length - 1) continue;   // trailing slash: directory entry
+            if (seg.Length == 0 || seg == "." || seg == "..") return "path traversal in entry name";
+            if (seg.EndsWith('.') || seg.EndsWith(' ')) return "entry segment ends with a dot or space";
+            if (ReservedDeviceNames.Contains(seg.Split('.')[0])) return "reserved device name in entry";
+        }
+        if (!string.Equals(segs[0], "NexusApp", StringComparison.OrdinalIgnoreCase))
+            return "entry outside the NexusApp top-level folder";
+        var relSegs = segs.Skip(1).Where(s => s.Length > 0).ToArray();
+        rel = string.Join('\\', relSegs);
+        if (rel.Length == 0) return null;
+        foreach (var s in relSegs)
+        {
+            if (s.EndsWith(OldSuffix, StringComparison.OrdinalIgnoreCase)) return "entry name ends in .old";
+            if (s.EndsWith(".new", StringComparison.OrdinalIgnoreCase)) return "entry name ends in .new";
+            if (string.Equals(s, StagingDirName, StringComparison.OrdinalIgnoreCase))
+                return "entry collides with the staging folder";
+        }
+        var file = relSegs[^1];
+        if (string.Equals(file, "install.marker", StringComparison.OrdinalIgnoreCase))
+            return "install.marker is not allowed in the portable payload";
+        if (string.Equals(file, SwapJournal.FileName, StringComparison.OrdinalIgnoreCase))
+            return "journal filename is not allowed in the payload";
+        if (string.Equals(file, LockFileName, StringComparison.OrdinalIgnoreCase))
+            return "lock filename is not allowed in the payload";
+        return null;
+    }
+
+    // Interface members are completed by later tasks; these throw until then so the class
+    // compiles without lying about what works.
+    public PortablePreflight Preflight(long zipBytes) => throw new NotImplementedException();
+    public PortableApplyResult Apply(string zipPath, string expectedSha256, Version version, string currentVersion) => throw new NotImplementedException();
+    public bool UnpackForManual(string zipPath, string expectedSha256, Version version) => throw new NotImplementedException();
+}

--- a/NexusApp/Services/PortableUpdater.cs
+++ b/NexusApp/Services/PortableUpdater.cs
@@ -15,6 +15,8 @@ public enum PortableApplyOutcome { Completed, FailedNothingChanged, FailedRolled
 
 public sealed record PortableApplyResult(PortableApplyOutcome Outcome, string Reason);
 
+public sealed record SwapRecoveryResult(bool ShowSwapFailedNotice, string? AttemptedVersion);
+
 // Seam so UpdateService's state machine is testable without a filesystem or a real swap.
 internal interface IPortableSwapper
 {
@@ -540,6 +542,166 @@ public sealed class PortableUpdater : IPortableSwapper
         SaveJournal(journal);
         Logger.Error($"{UpdateService.Tag} rollback incomplete at {rel}; previous files are kept as {OldSuffix} and the verified download is retained; the next start finishes the restore");
         return new(PortableApplyOutcome.FailedRollbackIncomplete, reason);
+    }
+
+    // ---- Startup recovery ----
+
+    // Startup recovery: MUST run before UpdateService.PurgeStaleDownloads (which would delete
+    // the verified zip, the one artifact that can rebuild a broken folder). Reads the journal
+    // as untrusted input and either finishes a completed swap's cleanup or puts the previous
+    // version back after a crashed one.
+    public static SwapRecoveryResult RecoverAtStartup() =>
+        RecoverAtStartup(SwapJournal.DefaultPath, AppContext.BaseDirectory, NexusApp.AppInfo.Version);
+
+    internal static SwapRecoveryResult RecoverAtStartup(string journalPath, string baseDirectory,
+                                                        string runningVersion, int[]? retryDelaysMs = null)
+    {
+        var none = new SwapRecoveryResult(false, null);
+        if (!File.Exists(journalPath))
+        {
+            // A crash during the staging copy predates the journal, so a partial
+            // update-staging folder can sit in the install dir with nothing claiming it; the
+            // next Apply would wipe it, but the user may never run another update. The sweep
+            // must not race a LIVE Apply mid-copy (its journal does not exist yet either):
+            // Apply holds the exclusive lock for the whole swap, so take the same lock and
+            // treat failure as "an update is running or the folder is protected, not ours".
+            var orphan = Path.Combine(baseDirectory, StagingDirName);
+            if (Directory.Exists(orphan))
+            {
+                try
+                {
+                    using var sweepLock = new FileStream(Path.Combine(baseDirectory, LockFileName),
+                        FileMode.Create, FileAccess.Write, FileShare.None, 1, FileOptions.DeleteOnClose);
+                    Logger.Info($"{UpdateService.Tag} swap recovery: removing an unclaimed staging folder from an interrupted update");
+                    TryDeleteDir(orphan);
+                }
+                catch { /* a live update owns it, or the folder is protected; leave it */ }
+            }
+            return none;
+        }
+        var journal = SwapJournal.TryLoad(journalPath);
+        if (journal is null)
+        {
+            // Garbage or future-schema content is not ours to act on; discard it so the
+            // purge guard cannot wedge updates forever on an unreadable file.
+            Logger.Info($"{UpdateService.Tag} swap recovery: unreadable journal discarded");
+            TryDelete(journalPath);
+            return none;
+        }
+        string ourDir, journalDir;
+        try
+        {
+            ourDir = Path.GetFullPath(baseDirectory).TrimEnd('\\');
+            journalDir = Path.GetFullPath(journal.InstallDir).TrimEnd('\\');
+        }
+        catch { TryDelete(journalPath); return none; }
+        if (!string.Equals(ourDir, journalDir, StringComparison.OrdinalIgnoreCase))
+        {
+            if (!Directory.Exists(journalDir))
+            {
+                Logger.Info($"{UpdateService.Tag} swap recovery: journal points at a folder that no longer exists; discarded");
+                TryDelete(journalPath);
+                return none;
+            }
+            // This profile also serves the installer flavor and other portable copies; the
+            // journal belongs to a different install and only ITS instance may touch it.
+            Logger.Info($"{UpdateService.Tag} swap recovery: journal belongs to another install, leaving it alone");
+            return none;
+        }
+        var delays = retryDelaysMs ?? new[] { 500, 1000, 2000 };
+        // Serialize against a concurrently starting second instance recovering the same dir.
+        FileStream? lockFs = null;
+        try
+        {
+            lockFs = new FileStream(Path.Combine(journalDir, LockFileName),
+                FileMode.Create, FileAccess.Write, FileShare.None, 1, FileOptions.DeleteOnClose);
+        }
+        catch
+        {
+            Logger.Info($"{UpdateService.Tag} swap recovery: another instance holds the update lock; skipping this start");
+            return none;
+        }
+        try
+        {
+            // InProgress but the running exe IS the attempted version: the crash fell between
+            // the final flip and the Complete stamp, so the swap in fact finished.
+            if (journal.Status == SwapJournal.StatusComplete ||
+                string.Equals(runningVersion, journal.AttemptedVersion, StringComparison.Ordinal))
+                return CleanupCompleted(journal, journalPath, journalDir, delays);
+            return RestorePrevious(journal, journalPath, journalDir, delays);
+        }
+        finally { lockFs?.Dispose(); }
+    }
+
+    private static SwapRecoveryResult CleanupCompleted(SwapJournal journal, string journalPath,
+                                                       string installDir, int[] delays)
+    {
+        var allClean = true;
+        foreach (var op in journal.Ops)
+        {
+            if (!SwapJournal.IsSafeRel(installDir, op.Rel)) continue;   // tampered entry: touch nothing
+            var old = Path.Combine(installDir, op.Rel) + OldSuffix;
+            if (File.Exists(old) && !RetryDeleteWith(old, delays)) allClean = false;
+        }
+        if (!TryDeleteDir(Path.Combine(installDir, StagingDirName))) allClean = false;
+        if (allClean)
+        {
+            TryDelete(journalPath);
+            Logger.Info($"{UpdateService.Tag} portable swap complete");
+        }
+        else
+        {
+            // The old exe stays delete-locked for a few seconds after exit, and Controlled
+            // Folder Access can block the NEW exe's first purge. Housekeeping that will
+            // succeed on a later start never deserves an ERROR line.
+            journal.Status = SwapJournal.StatusComplete;
+            try { journal.Save(journalPath); } catch { }
+            Logger.Info($"{UpdateService.Tag} portable swap complete; some previous-version files are still in use and will be cleaned on a later start");
+        }
+        return new SwapRecoveryResult(false, null);
+    }
+
+    private static SwapRecoveryResult RestorePrevious(SwapJournal journal, string journalPath,
+                                                      string installDir, int[] delays)
+    {
+        var allRestored = true;
+        for (int i = journal.Ops.Count - 1; i >= 0; i--)
+        {
+            var op = journal.Ops[i];
+            if (op.Skipped || !SwapJournal.IsSafeRel(installDir, op.Rel)) continue;
+            var target = Path.Combine(installDir, op.Rel);
+            var old = target + OldSuffix;
+            if (File.Exists(old))
+            {
+                // The new file at the live name is reproducible from the kept zip; the .old
+                // set is not. Delete new, restore old.
+                if (File.Exists(target) && !RetryDeleteWith(target, delays)) { allRestored = false; continue; }
+                if (!RetryMoveWith(old, target, delays)) { allRestored = false; continue; }
+            }
+            // A new-only file (no .old pair) is deleted; but existence alone cannot tell a
+            // genuinely-added file from one this very method already restored on an earlier
+            // pass (previous bytes back at the live name, .old consumed, flags stale because
+            // the journal is only re-saved wholesale). OldMoved is the disambiguator: it was
+            // saved only after a real rename-out, so OldMoved=true in this branch means the
+            // .old was already moved back and the file on disk IS the previous version.
+            else if (!op.OldMoved && op.NewPlaced && File.Exists(target) && !RetryDeleteWith(target, delays))
+            {
+                allRestored = false;
+            }
+        }
+        TryDeleteDir(Path.Combine(installDir, StagingDirName));
+        if (allRestored)
+        {
+            TryDelete(journalPath);
+            Logger.Info($"{UpdateService.Tag} portable swap failed, previous version restored");
+        }
+        else
+        {
+            try { journal.Save(journalPath); } catch { }
+            Logger.Info($"{UpdateService.Tag} portable swap failed; some files are still in use, the restore finishes on a later start");
+        }
+        return new SwapRecoveryResult(true,
+            string.IsNullOrEmpty(journal.AttemptedVersion) ? null : journal.AttemptedVersion);
     }
 
     // ---- Small shared helpers ----

--- a/NexusApp/Services/PortableUpdater.cs
+++ b/NexusApp/Services/PortableUpdater.cs
@@ -797,7 +797,26 @@ public sealed class PortableUpdater : IPortableSwapper
         catch { return false; }
     }
 
-    // Completed by a later task; throws until then so the class compiles without lying
-    // about what works.
-    public bool UnpackForManual(string zipPath, string expectedSha256, Version version) => throw new NotImplementedException();
+    // The guided-manual fallback: the app does the verify and the unpack, the user does one
+    // Explorer copy. Strictly better than revealing the raw zip, and the floor every
+    // precondition failure lands on.
+    public bool UnpackForManual(string zipPath, string expectedSha256, Version version)
+    {
+        try
+        {
+            Logger.Info($"{UpdateService.Tag} unpack started");
+            var stagedRoot = Path.Combine(_updatesDir, version.ToString(3), "staged", "NexusApp");
+            VerifyAndExtract(zipPath, expectedSha256, stagedRoot);
+            Logger.Info($"{UpdateService.Tag} unpack complete, hash re-verified");
+            _openFolder(stagedRoot);
+            _openFolder(_installDir);
+            Logger.Info($"{UpdateService.Tag} manual handoff: unpacked and folders opened");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Logger.Error($"{UpdateService.Tag} manual unpack failed: {ex.Message}", ex);
+            return false;
+        }
+    }
 }

--- a/NexusApp/Services/PortableUpdater.cs
+++ b/NexusApp/Services/PortableUpdater.cs
@@ -272,9 +272,370 @@ public sealed class PortableUpdater : IPortableSwapper
         return new ExtractResult(hashes, total, destDir);
     }
 
-    // Interface members are completed by later tasks; these throw until then so the class
-    // compiles without lying about what works.
-    public PortablePreflight Preflight(long zipBytes) => throw new NotImplementedException();
-    public PortableApplyResult Apply(string zipPath, string expectedSha256, Version version, string currentVersion) => throw new NotImplementedException();
+    // Every reason returned here routes the UI to the guided manual flow, never to an error:
+    // a precondition failure is a different intentional path, and the reason line lands in
+    // nexus.log as "[UPDATE] portable swap unavailable: <reason>, offering manual handoff".
+    public PortablePreflight Preflight(long zipBytes)
+    {
+        var issue = PreflightPathIssue(_processPath, _installDir, _env);
+        if (issue != null) return new(false, issue);
+        if (_distribution() != "Portable") return new(false, "this is not the portable distribution");
+        // Layout sanity: a real portable install has the native loaders beside the exe.
+        if (!File.Exists(Path.Combine(_installDir, "e_sqlite3.dll")) ||
+            !File.Exists(Path.Combine(_installDir, "wpfgfx_cor3.dll")))
+            return new(false, "this folder does not look like a portable Nexus install");
+        try
+        {
+            if ((File.GetAttributes(_installDir) & FileAttributes.ReparsePoint) != 0)
+                return new(false, "the install folder is a link, not a real folder");
+        }
+        catch (Exception ex) { return new(false, $"the install folder could not be inspected: {ex.Message}"); }
+        if (_nexusProcessCount() > 1) return new(false, "another Nexus window is open");
+        // Writability probe: create + rename + delete catches Controlled Folder Access,
+        // read-only media, and ACL denials in one shot. Explorer stays allowed under CFA,
+        // so the manual fallback this reason routes to still works.
+        var probe = Path.Combine(_installDir, "nexus-update-probe-" + Path.GetRandomFileName());
+        try
+        {
+            File.WriteAllText(probe, "probe");
+            File.Move(probe, probe + ".r");
+            File.Delete(probe + ".r");
+        }
+        catch
+        {
+            // Both probe generations: the failure can hit before or after the rename step,
+            // and a leftover probe file would violate the portable-cleanliness rule.
+            try { if (File.Exists(probe)) File.Delete(probe); } catch { }
+            try { if (File.Exists(probe + ".r")) File.Delete(probe + ".r"); } catch { }
+            return new(false, "Nexus cannot write to its own folder here (folder protection, permissions, or read-only media)");
+        }
+        // Free space: the staging copy coexists with the originals, so the install volume
+        // transiently needs roughly twice the payload; the data volume needs zip plus
+        // extraction. A query failure (SUBST, quotas) is attempt-anyway, not a refusal.
+        try
+        {
+            var installDrive = new DriveInfo(Path.GetPathRoot(_installDir)!);
+            if (installDrive.DriveType == DriveType.Network)
+                return new(false, "the install folder is on a network drive");
+            if (installDrive.DriveType == DriveType.Removable)
+                Logger.Info($"{UpdateService.Tag} install folder is on removable media; a power cut mid-swap can corrupt it (the .old set is the recovery)");
+            if (installDrive.AvailableFreeSpace < zipBytes * 2 + FreeSpaceSlackBytes)
+                return new(false, "not enough free space in the install folder's drive");
+            if (new DriveInfo(Path.GetPathRoot(_updatesDir)!).AvailableFreeSpace < zipBytes * 2 + FreeSpaceSlackBytes)
+                return new(false, "not enough free space on the Windows drive to unpack the update");
+        }
+        catch (Exception ex)
+        {
+            Logger.Info($"{UpdateService.Tag} free-space probe inconclusive ({ex.Message}); attempting anyway");
+        }
+        return new(true, "");
+    }
+
+    public PortableApplyResult Apply(string zipPath, string expectedSha256, Version version, string currentVersion)
+    {
+        long zipBytes = 0;
+        try { zipBytes = new FileInfo(zipPath).Length; } catch { }
+        var pre = Preflight(zipBytes);
+        if (!pre.Ok) return new(PortableApplyOutcome.FailedNothingChanged, pre.Reason);
+
+        // Upgrade re-asserted against the ON-DISK exe, not just this process: a stale
+        // instance must never re-apply its download over an already-updated folder.
+        var baseline = OnDiskVersionOrFallback(Path.Combine(_installDir, "NexusApp.exe"), currentVersion);
+        if (!UpdateVerifier.IsUpgrade(baseline, version.ToString(3)))
+            return new(PortableApplyOutcome.FailedNothingChanged, "the update is not newer than the installed version");
+
+        FileStream? lockFs = null;
+        try
+        {
+            // Exclusive for the whole swap; DeleteOnClose means a crash can never leave a
+            // stale lock (the handle's death releases and removes it).
+            try
+            {
+                lockFs = new FileStream(Path.Combine(_installDir, LockFileName),
+                    FileMode.Create, FileAccess.Write, FileShare.None, 1, FileOptions.DeleteOnClose);
+            }
+            catch { return new(PortableApplyOutcome.FailedNothingChanged, "another update is already in progress"); }
+
+            Logger.Info($"{UpdateService.Tag} unpack started");
+            ExtractResult extracted;
+            var stagedRoot = Path.Combine(_updatesDir, version.ToString(3), "staged", "NexusApp");
+            try { extracted = VerifyAndExtract(zipPath, expectedSha256, stagedRoot); }
+            catch (Exception ex) { return new(PortableApplyOutcome.FailedNothingChanged, ex.Message); }
+            Logger.Info($"{UpdateService.Tag} unpack complete, hash re-verified ({extracted.FileHashes.Count} files)");
+
+            // Exact free-space check now that the true payload size is known.
+            try
+            {
+                if (new DriveInfo(Path.GetPathRoot(_installDir)!).AvailableFreeSpace < extracted.TotalBytes + FreeSpaceSlackBytes)
+                    return new(PortableApplyOutcome.FailedNothingChanged, "not enough free space in the install folder's drive");
+            }
+            catch { /* attempt anyway */ }
+
+            var stagingDir = Path.Combine(_installDir, StagingDirName);
+            try
+            {
+                if (Directory.Exists(stagingDir)) Directory.Delete(stagingDir, recursive: true);
+                CopyTree(extracted.PayloadRoot, stagingDir);
+            }
+            catch (Exception ex)
+            {
+                TryDeleteDir(stagingDir);
+                return new(PortableApplyOutcome.FailedNothingChanged, $"couldn't stage the update inside the install folder: {ex.Message}");
+            }
+            Logger.Info($"{UpdateService.Tag} staged copy placed inside the install folder");
+
+            return Flip(extracted, stagingDir, version, currentVersion);
+        }
+        finally { lockFs?.Dispose(); }
+    }
+
+    // Two-phase core. Phase order per file: journal the intent (write-ahead), clear any stale
+    // .old, rename current -> .old, rename staged -> current. NexusApp.exe goes strictly
+    // LAST so every earlier failure rolls back without ever touching the running image.
+    private PortableApplyResult Flip(ExtractResult extracted, string stagingDir, Version version, string currentVersion)
+    {
+        var rels = extracted.FileHashes.Keys
+            .Where(r => !string.Equals(r, "NexusApp.exe", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(r => r, StringComparer.OrdinalIgnoreCase)
+            .Append("NexusApp.exe")
+            .ToList();
+
+        // Reparse sweep over every directory a flip touches: a planted junction must never
+        // redirect a rename outside the install folder.
+        var installRoot = _installDir.TrimEnd('\\');
+        foreach (var dir in rels.Select(r => Path.GetDirectoryName(Path.Combine(_installDir, r))!)
+                                .Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            for (var d = dir; d.Length > installRoot.Length; d = Path.GetDirectoryName(d)!)
+                if (Directory.Exists(d) && (File.GetAttributes(d) & FileAttributes.ReparsePoint) != 0)
+                {
+                    TryDeleteDir(stagingDir);
+                    return new(PortableApplyOutcome.FailedNothingChanged, "a folder inside the install folder is a link");
+                }
+            Directory.CreateDirectory(dir);
+        }
+
+        var oneDrive = IsOneDriveManaged(_installDir);
+        var journal = new SwapJournal
+        {
+            AttemptedVersion = version.ToString(3),
+            PreviousVersion = currentVersion,
+            InstallDir = _installDir,
+        };
+        try { journal.Save(_journalPath); }
+        catch (Exception ex)
+        {
+            // Abort BEFORE any mutation if the write-ahead contract cannot be established,
+            // and take the staging folder back out of the install dir.
+            TryDeleteDir(stagingDir);
+            return new(PortableApplyOutcome.FailedNothingChanged, $"couldn't write the update journal: {ex.Message}");
+        }
+
+        foreach (var rel in rels)
+        {
+            var staged = Path.Combine(stagingDir, rel);
+            var target = Path.Combine(_installDir, rel);
+            var old = target + OldSuffix;
+            var nonCritical = string.Equals(rel, "README.txt", StringComparison.OrdinalIgnoreCase);
+            BeforeFlipHook?.Invoke(staged, rel);
+
+            // Re-verify the staged bytes against the hash captured during same-handle
+            // extraction, immediately before the rename: the staged tree sat in
+            // user-writable space between extraction and now.
+            string stagedHash;
+            try
+            {
+                using var sfs = File.OpenRead(staged);
+                stagedHash = Convert.ToHexString(SHA256.HashData(sfs)).ToLowerInvariant();
+            }
+            catch (Exception ex) { return Abort(journal, stagingDir, $"couldn't re-verify {rel}: {ex.Message}"); }
+            if (!string.Equals(stagedHash, extracted.FileHashes[rel], StringComparison.Ordinal))
+                return Abort(journal, stagingDir, $"{rel} changed between unpack and install");
+
+            var op = new SwapOp { Rel = rel, NonCritical = nonCritical };
+            journal.Ops.Add(op);
+            if (!SaveJournal(journal)) return Abort(journal, stagingDir, "couldn't update the journal");
+
+            if (File.Exists(old) && !RetryDelete(old, oneDrive))
+            {
+                if (nonCritical) { op.Skipped = true; SaveJournal(journal); Logger.Info($"{UpdateService.Tag} skipped {rel}: a leftover {rel}{OldSuffix} is in use"); continue; }
+                return Abort(journal, stagingDir, $"a leftover {rel}{OldSuffix} could not be removed");
+            }
+            if (File.Exists(target))
+            {
+                if (!RetryRename(target, old, oneDrive))
+                {
+                    if (nonCritical) { op.Skipped = true; SaveJournal(journal); Logger.Info($"{UpdateService.Tag} skipped {rel}: the current file is in use"); continue; }
+                    return Abort(journal, stagingDir, $"{rel} is held open by another program");
+                }
+                op.OldMoved = true;
+                if (!SaveJournal(journal)) return Abort(journal, stagingDir, "couldn't update the journal");
+            }
+            if (!RetryRename(staged, target, oneDrive))
+            {
+                if (nonCritical)
+                {
+                    if (op.OldMoved) { RetryRename(old, target, oneDrive); op.OldMoved = false; }
+                    op.Skipped = true; SaveJournal(journal);
+                    Logger.Info($"{UpdateService.Tag} skipped {rel}: couldn't place the new file");
+                    continue;
+                }
+                return Abort(journal, stagingDir, $"couldn't place the new {rel}");
+            }
+            op.NewPlaced = true;
+            if (!SaveJournal(journal)) return Abort(journal, stagingDir, "couldn't update the journal");
+        }
+
+        journal.Status = SwapJournal.StatusComplete;
+        if (!SaveJournal(journal)) return Abort(journal, stagingDir, "couldn't mark the journal complete");
+        TryDeleteDir(stagingDir);   // empty shells only: every file was renamed out of it
+        Logger.Info($"{UpdateService.Tag} flips complete, new version in place");
+        return new(PortableApplyOutcome.Completed, "");
+    }
+
+    // Roll back every completed pair in reverse. The running app cannot be file-locked out
+    // of its own renames, so this normally restores the folder exactly. If a rename still
+    // fails (AV holding a file), STOP: keep the complete .old set and the verified zip, keep
+    // the journal InProgress, and say exactly where it stuck; the next start finishes the
+    // restore. The folder is never left without a stated recovery path.
+    private PortableApplyResult Abort(SwapJournal journal, string stagingDir, string reason)
+    {
+        // The in-memory status may already read Complete (the final stamp's save is one of
+        // the failure paths that land here). It must never reach disk that way: a stuck
+        // rollback saves the journal below, and a Complete status over a half-rolled-back
+        // folder would send startup recovery down the cleanup branch, deleting the .old set
+        // instead of restoring it.
+        journal.Status = SwapJournal.StatusInProgress;
+        Logger.Error($"{UpdateService.Tag} portable swap failed: {reason}; rolling back");
+        var oneDrive = IsOneDriveManaged(_installDir);
+        for (int i = journal.Ops.Count - 1; i >= 0; i--)
+        {
+            var op = journal.Ops[i];
+            if (op.Skipped) continue;
+            var target = Path.Combine(_installDir, op.Rel);
+            var old = target + OldSuffix;
+            if (op.NewPlaced)
+            {
+                if (!RetryRename(target, Path.Combine(stagingDir, op.Rel), oneDrive))
+                    return RollbackStuck(journal, op.Rel, reason);
+                op.NewPlaced = false;
+                SaveJournal(journal);
+            }
+            if (op.OldMoved)
+            {
+                if (!RetryRename(old, target, oneDrive))
+                    return RollbackStuck(journal, op.Rel, reason);
+                op.OldMoved = false;
+                SaveJournal(journal);
+            }
+        }
+        TryDelete(_journalPath);
+        TryDeleteDir(stagingDir);
+        Logger.Info($"{UpdateService.Tag} rolled back, nothing changed");
+        return new(PortableApplyOutcome.FailedRolledBack, reason);
+    }
+
+    private PortableApplyResult RollbackStuck(SwapJournal journal, string rel, string reason)
+    {
+        SaveJournal(journal);
+        Logger.Error($"{UpdateService.Tag} rollback incomplete at {rel}; previous files are kept as {OldSuffix} and the verified download is retained; the next start finishes the restore");
+        return new(PortableApplyOutcome.FailedRollbackIncomplete, reason);
+    }
+
+    // ---- Small shared helpers ----
+
+    private bool SaveJournal(SwapJournal journal)
+    {
+        try { journal.Save(_journalPath); return true; }
+        catch (Exception ex) { Logger.Error($"{UpdateService.Tag} couldn't write the update journal", ex); return false; }
+    }
+
+    private bool RetryRename(string from, string to, bool oneDrive) =>
+        RetryMoveWith(from, to, EffectiveDelays(oneDrive));
+
+    private bool RetryDelete(string path, bool oneDrive) =>
+        RetryDeleteWith(path, EffectiveDelays(oneDrive));
+
+    // OneDrive-managed folders (Known Folder Move) hold transient sync locks longer than AV
+    // scans do; the backoff doubles rather than switching to a different strategy.
+    private int[] EffectiveDelays(bool oneDrive) =>
+        oneDrive ? _retryDelaysMs.Select(d => d * 2).ToArray() : _retryDelaysMs;
+
+    internal static bool RetryMoveWith(string from, string to, int[] delays)
+    {
+        for (int attempt = 0; ; attempt++)
+        {
+            try { File.Move(from, to); return true; }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                if (attempt >= delays.Length) return false;
+                Thread.Sleep(delays[attempt]);
+            }
+        }
+    }
+
+    internal static bool RetryDeleteWith(string path, int[] delays)
+    {
+        for (int attempt = 0; ; attempt++)
+        {
+            try
+            {
+                // Zip extractors and users set ReadOnly on README/Web content; it blocks
+                // delete (not rename), so clear it first.
+                File.SetAttributes(path, FileAttributes.Normal);
+                File.Delete(path);
+                return true;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                if (attempt >= delays.Length) return false;
+                Thread.Sleep(delays[attempt]);
+            }
+        }
+    }
+
+    private static bool IsOneDriveManaged(string dir)
+    {
+        const FileAttributes RecallOnDataAccess = (FileAttributes)0x400000;
+        try { return (File.GetAttributes(dir) & RecallOnDataAccess) != 0; }
+        catch { return false; }
+    }
+
+    private static string OnDiskVersionOrFallback(string exePath, string fallback)
+    {
+        try
+        {
+            var fvi = FileVersionInfo.GetVersionInfo(exePath);
+            if (Version.TryParse(fvi.FileVersion, out var v) && v.Build >= 0) return v.ToString(3);
+        }
+        catch { }
+        // No readable version resource (dev builds, test fixtures): the caller's process
+        // version already gated this upgrade once.
+        return fallback;
+    }
+
+    private static void CopyTree(string from, string to)
+    {
+        Directory.CreateDirectory(to);
+        foreach (var dir in Directory.GetDirectories(from, "*", SearchOption.AllDirectories))
+            Directory.CreateDirectory(Path.Combine(to, Path.GetRelativePath(from, dir)));
+        foreach (var file in Directory.GetFiles(from, "*", SearchOption.AllDirectories))
+            File.Copy(file, Path.Combine(to, Path.GetRelativePath(from, file)));
+    }
+
+    private static void TryDelete(string path)
+    {
+        try { if (File.Exists(path)) { File.SetAttributes(path, FileAttributes.Normal); File.Delete(path); } }
+        catch { /* best effort; a later start retries */ }
+    }
+
+    private static bool TryDeleteDir(string dir)
+    {
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); return true; }
+        catch { return false; }
+    }
+
+    // Completed by a later task; throws until then so the class compiles without lying
+    // about what works.
     public bool UnpackForManual(string zipPath, string expectedSha256, Version version) => throw new NotImplementedException();
 }

--- a/NexusApp/Services/PortableUpdater.cs
+++ b/NexusApp/Services/PortableUpdater.cs
@@ -54,6 +54,9 @@ public sealed class PortableUpdater : IPortableSwapper
     public const string StagingDirName = "update-staging";
     public const string LockFileName = "update.lock";
     public const string OldSuffix = ".old";
+    // Where startup recovery parks a new-version file while it renames the previous one back
+    // over the live name. Reserved against payload collision by NormalizeEntry.
+    public const string NewSuffix = ".new";
     internal const int MaxZipEntries = 4096;
     internal const long MaxExtractedBytes = 600L * 1024 * 1024;
     internal const long FreeSpaceSlackBytes = 50L * 1024 * 1024;
@@ -191,7 +194,7 @@ public sealed class PortableUpdater : IPortableSwapper
         foreach (var s in relSegs)
         {
             if (s.EndsWith(OldSuffix, StringComparison.OrdinalIgnoreCase)) return "entry name ends in .old";
-            if (s.EndsWith(".new", StringComparison.OrdinalIgnoreCase)) return "entry name ends in .new";
+            if (s.EndsWith(NewSuffix, StringComparison.OrdinalIgnoreCase)) return "entry name ends in .new";
             if (string.Equals(s, StagingDirName, StringComparison.OrdinalIgnoreCase))
                 return "entry collides with the staging folder";
         }
@@ -358,6 +361,15 @@ public sealed class PortableUpdater : IPortableSwapper
             }
             catch { return new(PortableApplyOutcome.FailedNothingChanged, "another update is already in progress"); }
 
+            // A journal on disk means unfinished business that only startup recovery may
+            // resolve: a sibling install's in-flight swap (the journal path is per profile,
+            // not per folder), this install's own stuck rollback whose .old files are the ONLY
+            // copy of the previous version, or a Complete journal whose cleanup is pending.
+            // Starting a new swap would overwrite the journal and take those files with it.
+            if (File.Exists(_journalPath))
+                return new(PortableApplyOutcome.FailedNothingChanged,
+                           "a previous update has not finished; restart Nexus and try again");
+
             Logger.Info($"{UpdateService.Tag} unpack started");
             ExtractResult extracted;
             var stagedRoot = Path.Combine(_updatesDir, version.ToString(3), "staged", "NexusApp");
@@ -391,9 +403,10 @@ public sealed class PortableUpdater : IPortableSwapper
         finally { lockFs?.Dispose(); }
     }
 
-    // Two-phase core. Phase order per file: journal the intent (write-ahead), clear any stale
-    // .old, rename current -> .old, rename staged -> current. NexusApp.exe goes strictly
-    // LAST so every earlier failure rolls back without ever touching the running image.
+    // Two-phase core. Phase order per file: re-verify the staged bytes, clear any stale .old,
+    // journal the intent (write-ahead), rename current -> .old, rename staged -> current.
+    // NexusApp.exe goes strictly LAST so every earlier failure rolls back without ever
+    // touching the running image.
     private PortableApplyResult Flip(ExtractResult extracted, string stagingDir, Version version, string currentVersion)
     {
         var rels = extracted.FileHashes.Keys
@@ -454,15 +467,22 @@ public sealed class PortableUpdater : IPortableSwapper
             if (!string.Equals(stagedHash, extracted.FileHashes[rel], StringComparison.Ordinal))
                 return Abort(journal, stagingDir, $"{rel} changed between unpack and install");
 
+            // A leftover .old from an older failed swap goes BEFORE the op is journaled, never
+            // after: a crash between the two would leave recovery a journal entry pointing at
+            // stale bytes and it would restore THOSE as "the previous version". Nothing is
+            // claimed until the only .old that can exist is this swap's own. A non-critical
+            // file that cannot be cleared is skipped without a journal entry, because nothing
+            // was mutated for it and there is nothing to roll back.
+            if (File.Exists(old) && !RetryDelete(old, oneDrive))
+            {
+                if (nonCritical) { Logger.Info($"{UpdateService.Tag} skipped {rel}: a leftover {rel}{OldSuffix} is in use"); continue; }
+                return Abort(journal, stagingDir, $"a leftover {rel}{OldSuffix} could not be removed");
+            }
+
             var op = new SwapOp { Rel = rel, NonCritical = nonCritical };
             journal.Ops.Add(op);
             if (!SaveJournal(journal)) return Abort(journal, stagingDir, "couldn't update the journal");
 
-            if (File.Exists(old) && !RetryDelete(old, oneDrive))
-            {
-                if (nonCritical) { op.Skipped = true; SaveJournal(journal); Logger.Info($"{UpdateService.Tag} skipped {rel}: a leftover {rel}{OldSuffix} is in use"); continue; }
-                return Abort(journal, stagingDir, $"a leftover {rel}{OldSuffix} could not be removed");
-            }
             if (File.Exists(target))
             {
                 if (!RetryRename(target, old, oneDrive))
@@ -624,9 +644,16 @@ public sealed class PortableUpdater : IPortableSwapper
         try
         {
             // InProgress but the running exe IS the attempted version: the crash fell between
-            // the final flip and the Complete stamp, so the swap in fact finished.
-            if (journal.Status == SwapJournal.StatusComplete ||
-                string.Equals(runningVersion, journal.AttemptedVersion, StringComparison.Ordinal))
+            // the final flip and the Complete stamp, so the swap in fact finished. A running
+            // version NEWER than the attempt counts the same way: the guided manual flow can
+            // legitimately land a newer copy than this journal ever attempted, and restoring
+            // the .old set over it would build a mixed folder. Versions that do not parse
+            // (dev builds, hand-edited fixtures) keep the exact-match fallback.
+            var finished = Version.TryParse(runningVersion, out var running) &&
+                           Version.TryParse(journal.AttemptedVersion, out var attempted)
+                ? running >= attempted
+                : string.Equals(runningVersion, journal.AttemptedVersion, StringComparison.Ordinal);
+            if (journal.Status == SwapJournal.StatusComplete || finished)
                 return CleanupCompleted(journal, journalPath, journalDir, delays);
             return RestorePrevious(journal, journalPath, journalDir, delays);
         }
@@ -642,6 +669,11 @@ public sealed class PortableUpdater : IPortableSwapper
             if (!SwapJournal.IsSafeRel(installDir, op.Rel)) continue;   // tampered entry: touch nothing
             var old = Path.Combine(installDir, op.Rel) + OldSuffix;
             if (File.Exists(old) && !RetryDeleteWith(old, delays)) allClean = false;
+            // A .new can outlive a restore attempt that later healed into the completed
+            // branch (the running exe turned out to be the attempted version); it is residue
+            // either way, and the portable folder must not keep it.
+            var pending = Path.Combine(installDir, op.Rel) + NewSuffix;
+            if (File.Exists(pending) && !RetryDeleteWith(pending, delays)) allClean = false;
         }
         if (!TryDeleteDir(Path.Combine(installDir, StagingDirName))) allClean = false;
         if (allClean)
@@ -671,12 +703,30 @@ public sealed class PortableUpdater : IPortableSwapper
             if (op.Skipped || !SwapJournal.IsSafeRel(installDir, op.Rel)) continue;
             var target = Path.Combine(installDir, op.Rel);
             var old = target + OldSuffix;
+            var pending = target + NewSuffix;
             if (File.Exists(old))
             {
-                // The new file at the live name is reproducible from the kept zip; the .old
-                // set is not. Delete new, restore old.
-                if (File.Exists(target) && !RetryDeleteWith(target, delays)) { allRestored = false; continue; }
-                if (!RetryMoveWith(old, target, delays)) { allRestored = false; continue; }
+                // Rename-only, exactly like the in-session Abort: this process has already
+                // memory-mapped the loose natives beside the exe (they load before OnStartup),
+                // and Windows refuses to DELETE a mapped image while it happily RENAMES one.
+                // Deleting at the live name would wedge recovery on every future start.
+                // Order is chosen so the live name is never left empty: vacate only when
+                // something is there, and put the parked file back if the restore fails.
+                if (File.Exists(target))
+                {
+                    // A .new parked by an earlier interrupted pass would block the vacate.
+                    if (File.Exists(pending) && !RetryDeleteWith(pending, delays)) { allRestored = false; continue; }
+                    if (!RetryMoveWith(target, pending, delays)) { allRestored = false; continue; }
+                }
+                if (!RetryMoveWith(old, target, delays))
+                {
+                    // Disk state, not this pass's bookkeeping, decides the move-back: a crash
+                    // inside the vacate-then-restore window leaves a re-entry that STARTS with
+                    // an empty live name and a waiting .new, and it must be put back too.
+                    if (File.Exists(pending) && !File.Exists(target)) RetryMoveWith(pending, target, delays);
+                    allRestored = false;
+                    continue;
+                }
             }
             // A new-only file (no .old pair) is deleted; but existence alone cannot tell a
             // genuinely-added file from one this very method already restored on an earlier
@@ -688,6 +738,11 @@ public sealed class PortableUpdater : IPortableSwapper
             {
                 allRestored = false;
             }
+            // The parked new-version file is deletable as soon as nothing maps it, which is
+            // the NEXT start at the latest. Sweeping here (not only inside the branch above)
+            // is what lets a pass that restored but could not delete converge later: a
+            // failure keeps the journal, and the following start finishes the housekeeping.
+            if (File.Exists(pending) && !RetryDeleteWith(pending, delays)) allRestored = false;
         }
         TryDeleteDir(Path.Combine(installDir, StagingDirName));
         if (allRestored)

--- a/NexusApp/Services/SettingsService.cs
+++ b/NexusApp/Services/SettingsService.cs
@@ -119,7 +119,12 @@ public class SettingsService
         try
         {
             Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
-            File.WriteAllText(_path, JsonSerializer.Serialize(settings, _opts));
+            // Write-temp-then-rename: a crash mid-write, or the portable self-swap's freshly
+            // spawned instance reading while the dying one writes, must never observe a
+            // truncated settings.json. The rename is atomic on the same volume.
+            var tmp = _path + ".tmp";
+            File.WriteAllText(tmp, JsonSerializer.Serialize(settings, _opts));
+            File.Move(tmp, _path, overwrite: true);
         }
         catch (Exception ex) { Logger.Error($"Failed to save settings to {_path}", ex); }
     }

--- a/NexusApp/Services/SwapJournal.cs
+++ b/NexusApp/Services/SwapJournal.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace NexusApp.Services;
+
+// Write-ahead journal for the portable self-swap. Every destructive rename is recorded and
+// FLUSHED to disk before it happens, so a crash at any instant leaves enough truth for the
+// next start to finish cleanup (status Complete) or put the previous version back (InProgress).
+//
+// Lives OUTSIDE the updates\ dir (PurgeStaleDownloads deletes that wholesale) and is treated
+// as UNTRUSTED INPUT on read-back: it sits in user-writable space, so schema, status, and
+// every relative path are re-validated before any file is touched.
+public sealed class SwapJournal
+{
+    public const int CurrentSchema = 1;
+    public const string FileName = "update_journal.json";
+    public const string StatusInProgress = "InProgress";
+    public const string StatusComplete = "Complete";
+
+    public static string DefaultPath => Path.Combine(AppPaths.Root, FileName);
+
+    public int Schema { get; set; } = CurrentSchema;
+    public string Status { get; set; } = StatusInProgress;
+    public string AttemptedVersion { get; set; } = "";
+    public string PreviousVersion { get; set; } = "";
+    public string InstallDir { get; set; } = "";
+    public List<SwapOp> Ops { get; set; } = new();
+
+    private static readonly JsonSerializerOptions _opts = new() { WriteIndented = true };
+
+    // Rewrite-in-full, atomically: the journal IS the crash contract, so a crash during the
+    // journal write itself must never destroy the previous generation (a truncated journal
+    // would make recovery discard it and strand the .old set). Write a temp, hard-flush it,
+    // rename over the real file; the stale generation a crash can leave behind is safe
+    // because recovery re-checks file existence per op. Throws on failure; the caller aborts
+    // the swap before any mutation if the journal cannot be written.
+    public void Save(string path)
+    {
+        var tmp = path + ".tmp";
+        using (var fs = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None))
+        {
+            JsonSerializer.Serialize(fs, this, _opts);
+            fs.Flush(true);
+        }
+        File.Move(tmp, path, overwrite: true);
+    }
+
+    // Untrusted read: any parse problem, unknown schema or status, or a non-rooted install
+    // dir returns null and the caller treats the file as garbage. Never throws.
+    public static SwapJournal? TryLoad(string path)
+    {
+        try
+        {
+            if (!File.Exists(path)) return null;
+            var j = JsonSerializer.Deserialize<SwapJournal>(File.ReadAllText(path));
+            if (j is null || j.Schema != CurrentSchema) return null;
+            if (j.Status is not (StatusInProgress or StatusComplete)) return null;
+            if (string.IsNullOrWhiteSpace(j.InstallDir) || !Path.IsPathRooted(j.InstallDir)) return null;
+            // A JSON null survives deserialization as a null element (the UpdateManifest.Parse
+            // lesson); one would NRE recovery mid-restore, so the whole journal is refused.
+            if (j.Ops is null || j.Ops.Any(o => o is null)) return null;
+            return j;
+        }
+        catch { return null; }
+    }
+
+    // A journal entry may only name a plain relative file strictly inside the install dir:
+    // no roots, no traversal, no "." segments, no alternate data streams. Recovery acts on
+    // nothing that fails this, so a tampered journal can never become a delete primitive.
+    public static bool IsSafeRel(string installDir, string rel)
+    {
+        if (string.IsNullOrWhiteSpace(rel)) return false;
+        if (rel.Contains(':') || Path.IsPathRooted(rel)) return false;
+        foreach (var seg in rel.Split('\\', '/'))
+            if (seg.Length == 0 || seg == "." || seg == "..") return false;
+        try
+        {
+            var root = Path.GetFullPath(installDir).TrimEnd('\\') + "\\";
+            var full = Path.GetFullPath(Path.Combine(root, rel));
+            return full.StartsWith(root, StringComparison.OrdinalIgnoreCase);
+        }
+        catch { return false; }
+    }
+}
+
+// One file's flip progress. OldMoved: current renamed to .old. NewPlaced: staged file renamed
+// into the vacated name. NonCritical files (README.txt) may end Skipped instead of failing.
+public sealed class SwapOp
+{
+    public string Rel { get; set; } = "";
+    public bool OldMoved { get; set; }
+    public bool NewPlaced { get; set; }
+    public bool NonCritical { get; set; }
+    public bool Skipped { get; set; }
+}

--- a/NexusApp/Services/SwapJournal.cs
+++ b/NexusApp/Services/SwapJournal.cs
@@ -15,6 +15,10 @@ namespace NexusApp.Services;
 public sealed class SwapJournal
 {
     public const int CurrentSchema = 1;
+    // A real journal is a few KB even with a full payload's ops. The cap is the
+    // UpdateManifest.MaxManifestBytes philosophy applied to the other untrusted file the
+    // update path reads: refuse before the bytes are pulled into memory.
+    public const int MaxJournalBytes = 64 * 1024;
     public const string FileName = "update_journal.json";
     public const string StatusInProgress = "InProgress";
     public const string StatusComplete = "Complete";
@@ -53,11 +57,15 @@ public sealed class SwapJournal
     {
         try
         {
-            if (!File.Exists(path)) return null;
+            var info = new FileInfo(path);
+            if (!info.Exists || info.Length > MaxJournalBytes) return null;
             var j = JsonSerializer.Deserialize<SwapJournal>(File.ReadAllText(path));
             if (j is null || j.Schema != CurrentSchema) return null;
             if (j.Status is not (StatusInProgress or StatusComplete)) return null;
             if (string.IsNullOrWhiteSpace(j.InstallDir) || !Path.IsPathRooted(j.InstallDir)) return null;
+            // Both versions reach the user verbatim through UpdateNotice.SwapFailedBody, so
+            // they are validated like any other untrusted string that becomes UI copy.
+            if (!Version.TryParse(j.AttemptedVersion, out _) || !Version.TryParse(j.PreviousVersion, out _)) return null;
             // A JSON null survives deserialization as a null element (the UpdateManifest.Parse
             // lesson); one would NRE recovery mid-restore, so the whole journal is refused.
             if (j.Ops is null || j.Ops.Any(o => o is null)) return null;

--- a/NexusApp/Services/UpdateNotice.cs
+++ b/NexusApp/Services/UpdateNotice.cs
@@ -37,6 +37,15 @@ public static class UpdateNotice
 
     public const string InstallConfirmBody =
         "Nexus will close and the installer will open. Your settings, work orders, and blueprints are kept.";
+
+    public const string InstallConfirmBodyPortable =
+        "Nexus will close for a moment and reopen as the new version. Your settings, work orders, and blueprints are kept.";
+
+    // Post-confirm staging failure: the app is still open, nothing was touched, and both
+    // recovery paths are named (house pattern: what happened, what the app did, what to do).
+    public const string PrepareFailedBody =
+        "Couldn't prepare the update. Nothing was changed. Try again, or update manually from Settings > Diagnostics.";
+
     public static string InstallConfirmTitle(Version v) => $"Install Nexus {v.ToString(3)} now?";
 
     public static string UpdateBody(string current, Version available) =>
@@ -50,8 +59,29 @@ public static class UpdateNotice
     public static string ReadyBodyInstaller(Version v) =>
         $"Nexus {v.ToString(3)} is downloaded and verified.";
 
-    public static string ReadyBodyPortable(Version v) =>
-        $"Nexus {v.ToString(3)} is downloaded and verified. Close Nexus and swap in the new folder when you are ready.";
+    // Installer parity: same sentence as ReadyBodyInstaller. Kept as its own method so call
+    // sites and tests stay explicit about which flavor they are rendering.
+    public static string ReadyBodyPortable(Version v) => ReadyBodyInstaller(v);
+
+    public static string PreparingBody(Version v) =>
+        $"Preparing Nexus {v.ToString(3)}. Nexus will close and reopen in a moment.";
+
+    // The guided manual flow is a different, intentional flow, never an error: the app
+    // extracts and opens the folders, the user does one copy.
+    public static string ReadyBodyPortableManual(Version v) =>
+        $"Nexus {v.ToString(3)} is downloaded and verified. Nexus cannot replace its own files from " +
+        "this location, so this update finishes with one quick copy.";
+
+    public static string UnpackingBody(Version v) => $"Unpacking Nexus {v.ToString(3)}.";
+
+    public static string ManualHandoffBody(Version v) =>
+        $"Two folders are open: the new Nexus {v.ToString(3)} and your current Nexus. Close Nexus, " +
+        "then copy everything from the new folder into the current one, replacing files when asked.";
+
+    // Sentence order is the house pattern: what happened, what the app did, where you stand.
+    public static string SwapFailedBody(string attempted, string current) =>
+        $"The update to Nexus {attempted} could not finish. Nexus restored the previous version " +
+        $"and nothing changed. You are still on Nexus {current}.";
 
     public static string PostUpdateBody(string version) =>
         $"Nexus updated to v{version}. See what changed in About > Changelog.";
@@ -85,6 +115,7 @@ public static class UpdateNotice
             case "Verifying":
             case "ReadyToInstall":
             case "Installing":
+            case "ManualHandoff":
                 return availableVersion is null
                     ? FormatLastChecked(lastCheckedUtc)
                     : string.Create(CultureInfo.InvariantCulture, $"Nexus {availableVersion.ToString(3)} is available");

--- a/NexusApp/Services/UpdateNotice.cs
+++ b/NexusApp/Services/UpdateNotice.cs
@@ -46,6 +46,13 @@ public static class UpdateNotice
     public const string PrepareFailedBody =
         "Couldn't prepare the update. Nothing was changed. Try again, or update manually from Settings > Diagnostics.";
 
+    // The stuck-rollback state: the swap failed AND the rollback could not put every file
+    // back, so the previous version lives in .old files that only startup recovery can
+    // restore. Retrying in this session would be a lie, so this copy asks for the restart the
+    // recovery needs and no Try again button is offered beside it.
+    public const string RestorePendingBody =
+        "The update could not finish. Nexus will finish restoring the previous version the next time it starts. Close Nexus and start it again.";
+
     public static string InstallConfirmTitle(Version v) => $"Install Nexus {v.ToString(3)} now?";
 
     public static string UpdateBody(string current, Version available) =>

--- a/NexusApp/Services/UpdateService.cs
+++ b/NexusApp/Services/UpdateService.cs
@@ -5,7 +5,7 @@ using System.Text;
 namespace NexusApp.Services;
 
 // Names are load-bearing: UpdateNotice.StatusLine matches them as strings.
-public enum UpdateState { Idle, Checking, UpToDate, UpdateAvailable, Downloading, Verifying, ReadyToInstall, Installing, Failed }
+public enum UpdateState { Idle, Checking, UpToDate, UpdateAvailable, Downloading, Verifying, ReadyToInstall, Installing, ManualHandoff, Failed }
 
 // Why a check failed, in terms a user can act on. Classified from the HTTP status and which
 // URL failed, never from a response body (nothing unauthenticated is read). None covers every
@@ -120,6 +120,9 @@ public sealed class UpdateService
     private readonly string _updatesDir;
     private readonly bool _demo;
     private readonly Func<string, bool> _startProcess;
+    private readonly IPortableSwapper _swapper;
+    private readonly Func<bool> _purgeGuard;
+    private readonly Func<string?> _relaunchPath;
     private int _busy;   // Interlocked single-flight across check and download
 
     public UpdateState State { get; private set; } = UpdateState.Idle;
@@ -138,6 +141,23 @@ public sealed class UpdateService
     public long DownloadedBytes { get; private set; }
     public long TotalBytes { get; private set; }
 
+    // Portable self-swap surface. Availability is evaluated once per download (and honors
+    // PreferManualUpdate); the failure note renders PrepareFailedBody without leaving
+    // ReadyToInstall, because StatusLine's Failed arm narrates CHECK failures and would lie.
+    public bool PortableSwapAvailable { get; private set; }
+    public string? PortableSwapUnavailableReason { get; private set; }
+    public string? LastPortableApplyFailure { get; private set; }
+    public bool PortableApplyInProgress { get; private set; }
+    public bool ManualUnpackInProgress { get; private set; }
+
+    // Set only after a Completed swap; App.OnExit spawns this path as the process's LAST
+    // action so the new instance never overlaps this one's settings and database writes.
+    public string? PendingRelaunchPath { get; private set; }
+
+    // Session-scoped: the swap-failed strip's "Update manually" choice routes the next
+    // ReadyToInstall straight to the guided manual flow.
+    public bool PreferManualUpdate { get; set; }
+
     // Raised on the worker thread after every state change; UI subscribers marshal with
     // Dispatcher.Invoke themselves (the App.Shards.Changed pattern).
     public event Action? Changed;
@@ -150,7 +170,8 @@ public sealed class UpdateService
 
     internal UpdateService(SettingsService settings, IUpdateTransport transport, Func<byte[], byte[], bool> verify,
                            Func<string> distribution, string currentVersion, string updatesDir, bool isDemoProfile,
-                           Func<string, bool>? startProcess = null)
+                           Func<string, bool>? startProcess = null, IPortableSwapper? swapper = null,
+                           Func<bool>? purgeGuard = null, Func<string?>? relaunchPathProvider = null)
     {
         _settings = settings;
         _transport = transport;
@@ -164,6 +185,11 @@ public sealed class UpdateService
         // that is not running.
         _startProcess = startProcess ??
             (path => System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(path) { UseShellExecute = true }) is not null);
+        _swapper = swapper ?? new PortableUpdater();
+        // The journal existence check guards the purge: while one exists, recovery owns
+        // everything under updates\ (the verified zip is the crash-recovery artifact).
+        _purgeGuard = purgeGuard ?? (() => File.Exists(SwapJournal.DefaultPath));
+        _relaunchPath = relaunchPathProvider ?? (() => Environment.ProcessPath);
     }
 
     // Pure gate for the on-launch check: consent must be an explicit yes, the demo profile
@@ -320,6 +346,7 @@ public sealed class UpdateService
             catch (Exception ex) { TryDelete(partial); Fail($"couldn't finalize the download: {Reason(ex)}", ex); return; }
             DownloadedPath = dest;
             Logger.Info($"{Tag} download complete, hash verified");
+            if (_distribution() == "Portable") EvaluatePortablePreflight(asset.Size);
             SetState(UpdateState.ReadyToInstall);
         }
         finally { Interlocked.Exchange(ref _busy, 0); }
@@ -367,6 +394,127 @@ public sealed class UpdateService
         }
     }
 
+    // Decides which portable strip the UI shows the moment ReadyToInstall lands: the
+    // self-swap confirm, or the guided manual flow (with the reason logged, never shown as
+    // an error). Cheap probes only; Apply re-runs the full gate at click time.
+    private void EvaluatePortablePreflight(long zipBytes)
+    {
+        LastPortableApplyFailure = null;
+        if (PreferManualUpdate)
+        {
+            PortableSwapAvailable = false;
+            PortableSwapUnavailableReason = "manual update chosen";
+            Logger.Info($"{Tag} portable swap unavailable: manual update chosen, offering manual handoff");
+            return;
+        }
+        PortablePreflight pre;
+        try { pre = _swapper.Preflight(zipBytes); }
+        catch (Exception ex)
+        {
+            // The probes are individually defensive, but this call must never be able to
+            // strand a verified download short of ReadyToInstall: an escaped exception is a
+            // bug, and the honest landing is the manual flow with the cause in nexus.log.
+            pre = new PortablePreflight(false, "the update check could not inspect this install");
+            Logger.Error($"{Tag} portable preflight threw unexpectedly", ex);
+        }
+        PortableSwapAvailable = pre.Ok;
+        PortableSwapUnavailableReason = pre.Ok ? null : pre.Reason;
+        if (pre.Ok) Logger.Info($"{Tag} portable swap preconditions ok");
+        else Logger.Info($"{Tag} portable swap unavailable: {pre.Reason}, offering manual handoff");
+    }
+
+    // The portable twin of LaunchInstaller: same click-gated re-verify philosophy, but the
+    // whole verify-extract-stage-flip sequence runs here (via PortableUpdater) while the app
+    // stays alive to roll back. True = files flipped; the CALLER shuts the app down and
+    // App.OnExit spawns PendingRelaunchPath last.
+    public async Task<bool> ApplyPortableAsync()
+    {
+        if (_demo) return false;
+        if (State != UpdateState.ReadyToInstall || DownloadedPath is null || Available is null) return false;
+        if (_distribution() != "Portable")
+        {
+            Logger.Info($"{Tag} portable swap refused: not the portable distribution");
+            return false;
+        }
+        var asset = Available.AssetFor("Portable");
+        if (asset is null) return false;
+        if (Interlocked.Exchange(ref _busy, 1) != 0) return false;
+        try
+        {
+            LastPortableApplyFailure = null;
+            LastFailureWasUserInitiated = true;
+            var version = Available.Version;
+            var downloaded = DownloadedPath;
+            PortableApplyInProgress = true;
+            SetState(UpdateState.Installing);
+            PortableApplyResult result;
+            try
+            {
+                result = await Task.Run(() => _swapper.Apply(downloaded, asset.Sha256, version, _currentVersion)).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // The engine reports failures as results; an exception escaping it is a bug,
+                // but the state machine must still land somewhere honest and recoverable.
+                result = new PortableApplyResult(PortableApplyOutcome.FailedNothingChanged, Reason(ex));
+                Logger.Error($"{Tag} portable swap threw unexpectedly", ex);
+            }
+            if (result.Outcome == PortableApplyOutcome.Completed)
+            {
+                PendingRelaunchPath = _relaunchPath();
+                Logger.Info($"{Tag} handing off to relaunch, closing");
+                return true;
+            }
+            LastPortableApplyFailure = TextSanitizer.ForLog(result.Reason);
+            // The engine logs its own rollback story, but the FailedNothingChanged returns
+            // are silent by design there; this line guarantees EVERY user-visible apply
+            // failure has a nexus.log counterpart (feature-logging rule).
+            Logger.Error($"{Tag} portable swap failed: {LastPortableApplyFailure}");
+            PortableApplyInProgress = false;
+            SetState(UpdateState.ReadyToInstall);
+            return false;
+        }
+        finally
+        {
+            if (State != UpdateState.Installing) PortableApplyInProgress = false;
+            Interlocked.Exchange(ref _busy, 0);
+        }
+    }
+
+    // The guided manual flow: verify + unpack + open both folders, then hold in
+    // ManualHandoff while the user does the copy and closes Nexus themselves.
+    public async Task UnpackForManualAsync()
+    {
+        if (_demo) return;
+        if (State != UpdateState.ReadyToInstall || DownloadedPath is null || Available is null) return;
+        if (_distribution() != "Portable") return;
+        var asset = Available.AssetFor("Portable");
+        if (asset is null) return;
+        if (Interlocked.Exchange(ref _busy, 1) != 0) return;
+        try
+        {
+            LastPortableApplyFailure = null;
+            LastFailureWasUserInitiated = true;
+            var version = Available.Version;
+            var downloaded = DownloadedPath;
+            ManualUnpackInProgress = true;
+            SetState(UpdateState.Installing);
+            var ok = await Task.Run(() => _swapper.UnpackForManual(downloaded, asset.Sha256, version)).ConfigureAwait(false);
+            ManualUnpackInProgress = false;
+            if (ok) SetState(UpdateState.ManualHandoff);
+            else
+            {
+                LastPortableApplyFailure = "couldn't unpack the update";
+                SetState(UpdateState.ReadyToInstall);
+            }
+        }
+        finally
+        {
+            ManualUnpackInProgress = false;
+            Interlocked.Exchange(ref _busy, 0);
+        }
+    }
+
     // Portable handoff: reveal the verified download so the user can do the folder swap.
     public void OpenDownloadFolder()
     {
@@ -384,6 +532,13 @@ public sealed class UpdateService
     // aborted .partial files) and gets removed wholesale before any new download starts.
     public void PurgeStaleDownloads()
     {
+        // While a swap journal exists, startup recovery owns everything under updates\ (the
+        // verified zip is the crash-recovery artifact); purging now would destroy it.
+        if (_purgeGuard())
+        {
+            Logger.Info($"{Tag} purge skipped: a swap journal is present");
+            return;
+        }
         // Not an error: the usual cause is an installer the user left open holding its own file.
         // Housekeeping that will succeed on a later start does not deserve an ERROR line.
         try { if (Directory.Exists(_updatesDir)) Directory.Delete(_updatesDir, recursive: true); }

--- a/NexusApp/Services/UpdateService.cs
+++ b/NexusApp/Services/UpdateService.cs
@@ -147,6 +147,11 @@ public sealed class UpdateService
     public bool PortableSwapAvailable { get; private set; }
     public string? PortableSwapUnavailableReason { get; private set; }
     public string? LastPortableApplyFailure { get; private set; }
+
+    // True when the last apply ended with the rollback stuck: the previous version is sitting
+    // in .old files that only startup recovery can put back, so the surfaces show the
+    // restart-to-restore copy instead of an unusable Try again.
+    public bool LastApplyLeftRestorePending { get; private set; }
     public bool PortableApplyInProgress { get; private set; }
     public bool ManualUnpackInProgress { get; private set; }
 
@@ -407,6 +412,18 @@ public sealed class UpdateService
             Logger.Info($"{Tag} portable swap unavailable: manual update chosen, offering manual handoff");
             return;
         }
+        // A pending journal means the engine will refuse this swap anyway (its .old files can
+        // be the only copy of a previous version), so the strip routes straight to the guided
+        // manual flow instead of offering a Try again that cannot work until a restart. The
+        // manual copy converges safely: startup recovery heals the journal to Complete once
+        // the running version equals the attempted one.
+        if (_purgeGuard())
+        {
+            PortableSwapAvailable = false;
+            PortableSwapUnavailableReason = "a previous update has not finished; restart Nexus to complete it";
+            Logger.Info($"{Tag} portable swap unavailable: {PortableSwapUnavailableReason}, offering manual handoff");
+            return;
+        }
         PortablePreflight pre;
         try { pre = _swapper.Preflight(zipBytes); }
         catch (Exception ex)
@@ -442,6 +459,7 @@ public sealed class UpdateService
         try
         {
             LastPortableApplyFailure = null;
+            LastApplyLeftRestorePending = false;
             LastFailureWasUserInitiated = true;
             var version = Available.Version;
             var downloaded = DownloadedPath;
@@ -466,6 +484,7 @@ public sealed class UpdateService
                 return true;
             }
             LastPortableApplyFailure = TextSanitizer.ForLog(result.Reason);
+            LastApplyLeftRestorePending = result.Outcome == PortableApplyOutcome.FailedRollbackIncomplete;
             // The engine logs its own rollback story, but the FailedNothingChanged returns
             // are silent by design there; this line guarantees EVERY user-visible apply
             // failure has a nexus.log counterpart (feature-logging rule).
@@ -494,6 +513,9 @@ public sealed class UpdateService
         try
         {
             LastPortableApplyFailure = null;
+            // A manual unpack is a different attempt: its own failure must regain the Try again
+            // affordance instead of inheriting the earlier swap's restart-to-restore copy.
+            LastApplyLeftRestorePending = false;
             LastFailureWasUserInitiated = true;
             var version = Available.Version;
             var downloaded = DownloadedPath;

--- a/NexusApp/Views/CargoPlannerPage.cs
+++ b/NexusApp/Views/CargoPlannerPage.cs
@@ -55,6 +55,9 @@ public sealed class CargoPlannerPage : UserControl
         Render();
     }
 
+    // Portable self-swap: release the embedded browser's handles on Web\cargo before files are renamed.
+    internal void ShutdownWebViewForUpdate() => _viewport.ShutdownForUpdate();
+
     // The planner shows ONLY ships fully signed off in Grid Studio, with their saved overrides
     // (grid positions, sizes, accepted-container sets) applied to the model.
     private CargoShipCatalog LoadVisibleCatalog()

--- a/NexusApp/Views/CargoWebView.cs
+++ b/NexusApp/Views/CargoWebView.cs
@@ -154,6 +154,18 @@ public sealed class CargoWebView : UserControl
         }
     }
 
+    // Called once, right before the portable self-swap flips files: disposing the control
+    // ends the msedgewebview2 child processes so their read handles on Web\cargo release.
+    // Deliberately no re-init path; after a FAILED swap the 3D views stay degraded until the
+    // app restarts, which beats renaming files under a live embedded browser.
+    internal void ShutdownForUpdate()
+    {
+        try { _web.Dispose(); }
+        catch (Exception ex) { Logger.Error("[UI] WebView2 dispose before update failed", ex); }
+        _sharedEnv = null;
+        _ready = false;
+    }
+
     // Cancel any navigation off our own local virtual hosts. Fires for every navigation attempt
     // (page-initiated or otherwise); denials are logged once per occurrence.
     private static void OnNavigationStarting(object? sender, CoreWebView2NavigationStartingEventArgs e)

--- a/NexusApp/Views/CommandPage.cs
+++ b/NexusApp/Views/CommandPage.cs
@@ -485,6 +485,12 @@ public sealed class CommandPage : UserControl
                 install.Click += (_, _) => ShowInstallConfirm(v);
                 actions.Add(install);
                 break;
+            // A stuck rollback is not retryable in this session: the previous version is in
+            // .old files and only the next start's recovery can put it back. Say that, and
+            // offer no button that would fail.
+            case UpdateState.ReadyToInstall when svc.LastPortableApplyFailure != null && svc.LastApplyLeftRestorePending:
+                bodyText = UpdateNotice.RestorePendingBody;
+                break;
             case UpdateState.ReadyToInstall when svc.LastPortableApplyFailure != null:
                 bodyText = UpdateNotice.PrepareFailedBody;
                 var retry = StripButton("Try again");

--- a/NexusApp/Views/CommandPage.cs
+++ b/NexusApp/Views/CommandPage.cs
@@ -49,6 +49,8 @@ public sealed class CommandPage : UserControl
     private bool _postUpdateDismissed;             // user dismissed the updated-to strip this session
     private bool _postUpdateStripLogged;           // "shown" logged once, not on every rebuild
     private FrameworkElement? _updateStrip;        // current update strip element
+    private bool _swapFailedDismissed;             // user dismissed the swap-failed strip this session
+    private bool _swapFailedStripLogged;           // "shown" logged once, not on every rebuild
 
     // ── Operations entrance (tab-open only; never on data ticks) ──
     // Fires once per tab-open visit (MainWindow's SetActivePage calls PlayEntrance after
@@ -101,6 +103,8 @@ public sealed class CommandPage : UserControl
         if (_relaunchStrip != null) _root.Children.Add(_relaunchStrip);
         var postUpdate = PostUpdateStrip();
         if (postUpdate != null) _root.Children.Add(postUpdate);
+        var swapFailed = SwapFailedStrip();
+        if (swapFailed != null) _root.Children.Add(swapFailed);
         var consent = ConsentStrip();
         if (consent != null) _root.Children.Add(consent);
         _updateStrip = UpdateStrip();
@@ -407,13 +411,56 @@ public sealed class CommandPage : UserControl
             });
     }
 
+    // One-session notice after startup recovery restored the previous version (a swap
+    // crashed mid-flight last session). Try again re-enters the normal flow with a fresh
+    // check; Update manually routes the next ReadyToInstall to the guided manual flow.
+    private FrameworkElement? SwapFailedStrip()
+    {
+        if (_swapFailedDismissed || AppPaths.IsDemoProfile) return null;
+        if (App.SwapFailedAttemptedVersion is not { } attempted) return null;
+        if (!_swapFailedStripLogged)
+        {
+            _swapFailedStripLogged = true;
+            Logger.Info("[UI] swap-failed notice shown on Operations");
+        }
+        var tryAgain = StripButton("Try again");
+        tryAgain.Click += (_, _) =>
+        {
+            _swapFailedDismissed = true;
+            Logger.Info("[UI] swap-failed notice: try again");
+            _ = App.Update.CheckAsync(manual: true);
+            Refresh();
+        };
+        var manual = StripButton("Update manually");
+        manual.Click += (_, _) =>
+        {
+            _swapFailedDismissed = true;
+            Logger.Info("[UI] swap-failed notice: update manually");
+            App.Update.PreferManualUpdate = true;
+            _ = App.Update.CheckAsync(manual: true);
+            Refresh();
+        };
+        return NoticeStrip(UpdateNotice.UpdateEyebrow, UpdateNotice.SwapFailedBody(attempted, AppInfo.Version),
+            new[] { tryAgain, manual }, () =>
+            {
+                _swapFailedDismissed = true;
+                Logger.Info("[UI] swap-failed notice dismissed");
+                Refresh();
+            });
+    }
+
     // The live update strip: body and actions follow the service state. Dismiss is
     // session-scoped; the Settings > Diagnostics rows remain the persistent surface.
     private FrameworkElement? UpdateStrip()
     {
         var svc = App.Update;
         if (svc == null || _updateDismissed || svc.Available is null) return null;
-        if (svc.State is not (UpdateState.UpdateAvailable or UpdateState.Downloading or UpdateState.Verifying or UpdateState.ReadyToInstall)) return null;
+        // Installing is admitted only for the portable flows (the installer sets Installing
+        // right before shutdown and must not flash a strip); ManualHandoff holds the
+        // instruction line until the user closes Nexus themselves.
+        var portableBusy = svc.State == UpdateState.Installing && (svc.PortableApplyInProgress || svc.ManualUnpackInProgress);
+        if (svc.State is not (UpdateState.UpdateAvailable or UpdateState.Downloading or UpdateState.Verifying
+                or UpdateState.ReadyToInstall or UpdateState.ManualHandoff) && !portableBusy) return null;
 
         if (!_updateStripLogged)
         {
@@ -438,11 +485,39 @@ public sealed class CommandPage : UserControl
                 install.Click += (_, _) => ShowInstallConfirm(v);
                 actions.Add(install);
                 break;
-            case UpdateState.ReadyToInstall:
+            case UpdateState.ReadyToInstall when svc.LastPortableApplyFailure != null:
+                bodyText = UpdateNotice.PrepareFailedBody;
+                var retry = StripButton("Try again");
+                // Retry whichever path failed: the self-swap when it is available, otherwise
+                // the guided manual unpack (its failure sets the same note).
+                retry.Click += (_, _) =>
+                {
+                    Logger.Info("[UI] portable update: try again");
+                    if (App.Update.PortableSwapAvailable) _ = RunPortableApply(v);
+                    else _ = App.Update.UnpackForManualAsync();
+                };
+                actions.Add(retry);
+                break;
+            case UpdateState.ReadyToInstall when svc.PortableSwapAvailable:
                 bodyText = UpdateNotice.ReadyBodyPortable(v);
-                var open = StripButton("Open folder");
-                open.Click += (_, _) => App.Update.OpenDownloadFolder();
-                actions.Add(open);
+                var installPortable = StripButton("Install update");
+                installPortable.Click += (_, _) => ShowInstallConfirm(v);
+                actions.Add(installPortable);
+                break;
+            case UpdateState.ReadyToInstall:
+                bodyText = UpdateNotice.ReadyBodyPortableManual(v);
+                var manual = StripButton("Set up manual update");
+                manual.Click += (_, _) => { Logger.Info("[UI] portable update: manual handoff chosen"); _ = App.Update.UnpackForManualAsync(); };
+                actions.Add(manual);
+                break;
+            case UpdateState.Installing when svc.ManualUnpackInProgress:
+                bodyText = UpdateNotice.UnpackingBody(v);
+                break;
+            case UpdateState.Installing:
+                bodyText = UpdateNotice.PreparingBody(v);
+                break;
+            case UpdateState.ManualHandoff:
+                bodyText = UpdateNotice.ManualHandoffBody(v);
                 break;
             default:
                 bodyText = UpdateNotice.UpdateBody(AppInfo.Version, v);
@@ -454,8 +529,11 @@ public sealed class CommandPage : UserControl
                 }
                 break;
         }
-        return NoticeStrip(UpdateNotice.UpdateEyebrow, bodyText, actions,
-            () => { _updateDismissed = true; Logger.Info("[UI] update notice dismissed"); Refresh(); });
+        // No buttons, no dismiss while the swap is preparing or unpacking: the phase is
+        // terminal and the strip is the progress line.
+        Action? onDismiss = portableBusy ? null :
+            () => { _updateDismissed = true; Logger.Info("[UI] update notice dismissed"); Refresh(); };
+        return NoticeStrip(UpdateNotice.UpdateEyebrow, bodyText, actions, onDismiss);
     }
 
     // Themed in-page confirmation (SettingsPage danger-modal pattern, accent chrome): the
@@ -478,7 +556,8 @@ public sealed class CommandPage : UserControl
         });
         body.Children.Add(new TextBlock
         {
-            Text = UpdateNotice.InstallConfirmBody, FontSize = 12.5, Foreground = Br("FgDimBrush"),
+            Text = AppInfo.Distribution == "Installer" ? UpdateNotice.InstallConfirmBody : UpdateNotice.InstallConfirmBodyPortable,
+            FontSize = 12.5, Foreground = Br("FgDimBrush"),
             TextWrapping = TextWrapping.Wrap, Margin = new Thickness(0, 10, 0, 0),
         });
         var actionRow = new StackPanel { Orientation = Orientation.Horizontal, HorizontalAlignment = HorizontalAlignment.Right, Margin = new Thickness(0, 18, 0, 0) };
@@ -494,10 +573,17 @@ public sealed class CommandPage : UserControl
         {
             Logger.Info("[UI] install update: confirmed");
             CloseInstallConfirm(cancelled: false);
-            if (App.Update.LaunchInstaller())
-                Application.Current.Shutdown();
+            if (AppInfo.Distribution == "Installer")
+            {
+                if (App.Update.LaunchInstaller())
+                    Application.Current.Shutdown();
+                else
+                    ShowVerifyFailedIfNeeded();
+            }
             else
-                ShowVerifyFailedIfNeeded();
+            {
+                _ = RunPortableApply(v);
+            }
         };
         actionRow.Children.Add(cancel);
         actionRow.Children.Add(confirm);
@@ -516,6 +602,54 @@ public sealed class CommandPage : UserControl
     private void CloseInstallConfirm(bool cancelled)
     {
         if (cancelled) Logger.Info("[UI] install update: cancelled");
+        _modalHost.Visibility = Visibility.Collapsed;
+        _modalHost.Children.Clear();
+    }
+
+    // Confirm already given: quiesce the UI (version-skew guard: nothing may lazily load
+    // PenImc or WebView2 natives after files change), release WebView2's file handles, then
+    // run the swap off-thread. On success the shutdown path relaunches; on failure the
+    // window comes back alive and the strip explains via LastPortableApplyFailure.
+    private async Task RunPortableApply(Version v)
+    {
+        var owner = Window.GetWindow(this);
+        ShowInstallingOverlay(v);
+        if (owner != null) owner.IsEnabled = false;
+        (owner as MainWindow)?.ShutdownWebViewsForUpdate();
+        var ok = await App.Update.ApplyPortableAsync();
+        if (ok)
+        {
+            Application.Current.Shutdown();
+            return;
+        }
+        if (owner != null) owner.IsEnabled = true;
+        CloseInstallingOverlay();
+    }
+
+    // Non-dismissible by design: the scrim doubles as the interaction guard while files are
+    // being flipped, and a one-second dark gap after it reads as an ordinary restart.
+    private void ShowInstallingOverlay(Version v)
+    {
+        _modalHost.Children.Clear();
+        _modalHost.Children.Add(new Border { Background = new SolidColorBrush(Color.FromArgb(0x9E, 0x03, 0x05, 0x08)) });
+        var body = new StackPanel();
+        body.Children.Add(new TextBlock
+        {
+            Text = UpdateNotice.PreparingBody(v), FontFamily = Hud.Font("TechFont"),
+            FontSize = 14, FontWeight = FontWeights.SemiBold, Foreground = Br("FgBrush"),
+            TextWrapping = TextWrapping.Wrap,
+        });
+        var panel = Hud.Panel(body, chamfer: 14, bg: Br("Bg2NavBrush"), border: Br("AccentStrongBrush"),
+                              padding: new Thickness(22, 20, 22, 22));
+        panel.MaxWidth = 470;
+        panel.VerticalAlignment = VerticalAlignment.Center;
+        panel.HorizontalAlignment = HorizontalAlignment.Center;
+        _modalHost.Children.Add(panel);
+        _modalHost.Visibility = Visibility.Visible;
+    }
+
+    private void CloseInstallingOverlay()
+    {
         _modalHost.Visibility = Visibility.Collapsed;
         _modalHost.Children.Clear();
     }

--- a/NexusApp/Views/GridStudioPage.cs
+++ b/NexusApp/Views/GridStudioPage.cs
@@ -81,6 +81,9 @@ public sealed class GridStudioPage : UserControl
         Render();
     }
 
+    // Portable self-swap: release the embedded browser's handles on Web\cargo before files are renamed.
+    internal void ShutdownWebViewForUpdate() => _viewport.ShutdownForUpdate();
+
     // -- layout --------------------------------------------------------------------
 
     private void Build()

--- a/NexusApp/Views/MainWindow.xaml.cs
+++ b/NexusApp/Views/MainWindow.xaml.cs
@@ -613,6 +613,15 @@ public partial class MainWindow : Window
         _gridStudioPage.OnShown();
     }
 
+    // Ends both embedded browser viewports (Cargo Planner + Grid Studio) so the portable
+    // self-swap can rename Web\cargo files without msedgewebview2 holding them open.
+    public void ShutdownWebViewsForUpdate()
+    {
+        Logger.Info("[UPDATE] closing embedded browser views before the swap");
+        _plannerPage?.ShutdownWebViewForUpdate();
+        _gridStudioPage?.ShutdownWebViewForUpdate();
+    }
+
     private AdminPage? _adminPage;
     private void InitAdminPage()
     {

--- a/NexusApp/Views/SettingsPage.cs
+++ b/NexusApp/Views/SettingsPage.cs
@@ -505,6 +505,38 @@ public sealed class SettingsPage : UserControl
         return Pane(panel);
     }
 
+    // Right-aligned dim note, the pattern the Downloading/Verifying mirrors already use.
+    private static TextBlock RightNote(string text, bool wrap = false) => new()
+    {
+        Text = text, FontSize = 11.5, Foreground = Hud.Br("FgDimBrush"),
+        HorizontalAlignment = HorizontalAlignment.Right,
+        TextWrapping = wrap ? TextWrapping.Wrap : TextWrapping.NoWrap,
+        MaxWidth = 260, TextAlignment = TextAlignment.Right,
+    };
+
+    // The power-user secondary action on every portable ReadyToInstall row (approved UX:
+    // Settings is the surface for hand-managing the swap).
+    private void AddOpenDownloadFolder()
+    {
+        var open = GhostButton("Open download folder");
+        open.Margin = new Thickness(0, 6, 0, 0);
+        open.Click += (_, _) => App.Update.OpenDownloadFolder();
+        _updateActionHost!.Children.Add(open);
+    }
+
+    // Settings twin of CommandPage.RunPortableApply: disable the window (interaction guard
+    // against version-skew lazy loads), release WebView2 handles, apply off-thread, shut
+    // down on success. No overlay here; the row text mirrors the Installing state.
+    private async Task RunPortableApplyFromSettings()
+    {
+        var owner = Window.GetWindow(this);
+        if (owner != null) owner.IsEnabled = false;
+        (owner as MainWindow)?.ShutdownWebViewsForUpdate();
+        var ok = await App.Update.ApplyPortableAsync();
+        if (ok) { Application.Current.Shutdown(); return; }
+        if (owner != null) owner.IsEnabled = true;
+    }
+
     // Keeps the Updates rows honest as the service moves through its states. Subscribed to
     // App.Update.Changed (worker thread), so it always marshals through the dispatcher.
     private void RefreshUpdateRows()
@@ -550,10 +582,41 @@ public sealed class SettingsPage : UserControl
                 };
                 _updateActionHost.Children.Add(install);
                 break;
+            case UpdateState.ReadyToInstall when svc.LastPortableApplyFailure != null:
+                _updateActionHost.Children.Add(RightNote(UpdateNotice.PrepareFailedBody, wrap: true));
+                var retryPortable = GhostButton("Try again");
+                // Retry whichever path failed (the CommandPage twin does the same).
+                retryPortable.Click += (_, _) =>
+                {
+                    Logger.Info("[UI] portable update: try again");
+                    if (App.Update.PortableSwapAvailable) _ = RunPortableApplyFromSettings();
+                    else _ = App.Update.UnpackForManualAsync();
+                };
+                _updateActionHost.Children.Add(retryPortable);
+                AddOpenDownloadFolder();
+                break;
+            case UpdateState.ReadyToInstall when svc.PortableSwapAvailable:
+                var installPortable = GhostButton("Install update");
+                // Captured while the row is built (the LaunchInstaller row's precedent): the
+                // prompt must name the version this button was made for.
+                var vPortable = svc.Available!.Version;
+                installPortable.Click += (_, _) =>
+                {
+                    var res = MessageBox.Show(
+                        UpdateNotice.InstallConfirmTitle(vPortable) + "\n\n" + UpdateNotice.InstallConfirmBodyPortable,
+                        "Install update", MessageBoxButton.YesNo, MessageBoxImage.Question, MessageBoxResult.Yes);
+                    if (res != MessageBoxResult.Yes) return;
+                    Logger.Info("[UI] install update: confirmed");
+                    _ = RunPortableApplyFromSettings();
+                };
+                _updateActionHost.Children.Add(installPortable);
+                AddOpenDownloadFolder();
+                break;
             case UpdateState.ReadyToInstall:
-                var open = GhostButton("Open download folder");
-                open.Click += (_, _) => App.Update.OpenDownloadFolder();
-                _updateActionHost.Children.Add(open);
+                var manualPortable = GhostButton("Set up manual update");
+                manualPortable.Click += (_, _) => { Logger.Info("[UI] portable update: manual handoff chosen"); _ = App.Update.UnpackForManualAsync(); };
+                _updateActionHost.Children.Add(manualPortable);
+                AddOpenDownloadFolder();
                 break;
             // The spec's rule for this row is "mirrors the strip": in-flight states show the
             // same approved bodies the Operations strip shows, never "No update available."
@@ -572,6 +635,15 @@ public sealed class SettingsPage : UserControl
                     FontSize = 11.5, Foreground = Hud.Br("FgDimBrush"),
                     HorizontalAlignment = HorizontalAlignment.Right,
                 });
+                break;
+            case UpdateState.Installing when svc.Available is { } ip && (svc.PortableApplyInProgress || svc.ManualUnpackInProgress):
+                // wrap: PreparingBody exceeds the row's 260px note width and must not clip.
+                _updateActionHost.Children.Add(RightNote(
+                    svc.ManualUnpackInProgress ? UpdateNotice.UnpackingBody(ip.Version) : UpdateNotice.PreparingBody(ip.Version),
+                    wrap: true));
+                break;
+            case UpdateState.ManualHandoff when svc.Available is { } mh:
+                _updateActionHost.Children.Add(RightNote(UpdateNotice.ManualHandoffBody(mh.Version), wrap: true));
                 break;
             default:
                 _updateActionHost.Children.Add(new TextBlock

--- a/NexusApp/Views/SettingsPage.cs
+++ b/NexusApp/Views/SettingsPage.cs
@@ -582,6 +582,12 @@ public sealed class SettingsPage : UserControl
                 };
                 _updateActionHost.Children.Add(install);
                 break;
+            // Stuck rollback (the CommandPage twin does the same): restoring is the next
+            // start's job, so the row says so and offers no Try again that would fail.
+            case UpdateState.ReadyToInstall when svc.LastPortableApplyFailure != null && svc.LastApplyLeftRestorePending:
+                _updateActionHost.Children.Add(RightNote(UpdateNotice.RestorePendingBody, wrap: true));
+                AddOpenDownloadFolder();
+                break;
             case UpdateState.ReadyToInstall when svc.LastPortableApplyFailure != null:
                 _updateActionHost.Children.Add(RightNote(UpdateNotice.PrepareFailedBody, wrap: true));
                 var retryPortable = GhostButton("Try again");

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Run Nexus directly. You do not need to install it.
 Nexus can check for new versions itself. The first time you run a version that supports it, Nexus asks once whether to enable update checks (Settings > Diagnostics has the toggle and a manual Check now button; nothing is contacted until you say yes or click Check now yourself).
 
 - **Installer:** when an update is available, Nexus offers to download it, verifies the download, and runs the installer for you. Your settings, work orders, and blueprints are kept.
-- **Portable:** Nexus downloads and verifies the new portable zip, then offers to open the folder. Close Nexus, extract the new `NexusApp` folder over the old one, and start it again.
+- **Portable:** Nexus installs the update itself. It downloads and verifies the new portable zip, unpacks it, verifies each file, replaces its own files, and restarts as the new version. Your settings, work orders, and blueprints are kept. If Nexus cannot replace its own files where it is installed, it offers a manual update instead. Nexus then unpacks the update and opens both folders, and you finish with one copy.
 
 Every download and install asks first. You can always update by hand from the [Releases](../../releases) page instead.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,6 +41,15 @@ Nexus has a small attack surface by design. Because no software is free of all v
 
 - **Offline by default.** Nexus makes no network calls out of the box. Update checks are strictly opt-in: nothing is contacted unless you enable them or click Check now yourself, and you can confirm that with a firewall. With checks enabled, Nexus contacts GitHub only (github.com and GitHub's own file-download host), fetches the latest version number and release files, and sends nothing about you or your data beyond the connection itself (GitHub sees your IP address, as with any web request). The toggle lives in Settings > Diagnostics. There is no telemetry and no account.
 - **Signed updates.** Update information is a manifest signed with a key held offline by the maintainer. The app verifies the signature and the file hashes before anything is installed, refuses downgrades, and asks you before every download and every install. A compromised download source or repository cannot make Nexus install anything: at worst, updates stop appearing.
+- **Portable self-update.** The portable version can install an update itself. Nexus does the update while it is open, and then restarts as the new version. No helper program runs, and no script runs. The signed manifest format does not change. Nexus does the update in this order:
+  - Nexus verifies the download against the signed manifest.
+  - Nexus opens the download one time and verifies it again on that open file handle. So the bytes that Nexus checks are the bytes that Nexus unpacks.
+  - Nexus unpacks the download, and then verifies each file again just before it puts that file in place.
+  - Nexus records each rename in a journal before that rename happens.
+  - Nexus replaces each file in the update with a rename. Nexus keeps each previous file as a `.old` file.
+  - Nexus restarts as the new version.
+- **Update recovery.** If an update stops part way, the next start puts the previous version back from the kept `.old` files. Nexus keeps the previous files and the verified download until the new version starts. The first start of the new version removes the `.old` files and the download.
+- **Safe conditions for the self-update.** Nexus tries the self-update only when the conditions are safe. Nexus does not try it in a protected folder, on a network drive, or with a second Nexus window open. Nexus then offers a manual update. When you choose it, Nexus verifies and unpacks the update and opens the new folder and your current folder. You then do one copy.
 - **No elevation.** Nexus installs and runs per user. Nexus never asks for admin rights.
 - **Reads the screen, not Star Citizen's memory.** Auto-scan uses the standard Windows APIs for screen capture and OCR. Nexus never reads Star Citizen's memory. Nexus never injects code, DLLs, or hooks into the Star Citizen process.
 - **No changes to game files.** Nexus includes the reference data. Nexus reads some Star Citizen files, but it never changes them:


### PR DESCRIPTION
## What

The portable version can now install updates itself. After the existing click-gated download and verification, the running app unpacks the update, verifies it again, replaces its own files, and restarts as the new version. The installer flavor is unchanged.

When the app cannot safely replace its own files (protected folder, network drive, another Nexus running, unexpected layout), it falls back to a guided manual flow: it unpacks the verified update and opens both folders so the update finishes with one copy. Nothing silent, every step asks first.

## Trust chain

- The downloaded zip is verified against the signed manifest, then verified again on one open file handle and unpacked from that same handle, so the bytes checked are the bytes used.
- Every file is hashed during unpacking and re-verified immediately before it is placed.
- Files are replaced with renames only. There is no overwrite path and no helper program, script, or manifest format change.

## Crash safety

- Every rename is recorded in a write-ahead journal before it happens.
- The next start reads the journal (as untrusted input), removes leftovers after a complete swap, or puts the previous version back from the kept .old files after an incomplete one. The verified download is kept until the new version starts once.
- Recovery is rename-based end to end, so files the process has loaded can still be moved.

## UI

Installer-parity strip on Operations (Install update, themed confirm, progress body), mirror rows in Settings > Diagnostics (with the power-user open-folder action), and a one-time notice if a crashed update was rolled back.

## Tests and docs

Suite grows 712 to 845, zero warnings. SECURITY.md, ARCHITECTURE.md, and README.md updated to describe the new flow honestly.