### PR TITLE
Upgrade to .NET 10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,11 @@ jobs:
 
       - uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
+
+      # Records which SDK the run resolved, so the log answers this itself.
+      - name: Show SDK
+        run: dotnet --info
 
       # Restoring the test project also restores the app project it references.
       - name: Restore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,8 @@ jobs:
 
       - uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '10.0.x'
+          # Single source of truth for the SDK version: global.json at the repo root.
+          global-json-file: ./global.json
 
       # Records which SDK the run resolved, so the log answers this itself.
       - name: Show SDK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,8 @@ jobs:
 
       - uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '10.0.x'
+          # Single source of truth for the SDK version: global.json at the repo root.
+          global-json-file: ./global.json
 
       - name: Determine version
         id: ver

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Determine version
         id: ver

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,8 +6,8 @@ boundary (network access, file access, and game-process access), see
 
 ## Overview
 
-NexusApp is a single-process **WPF desktop app** that targets **.NET 8**
-(`net8.0-windows`). The build publishes NexusApp self-contained for `win-x64`.
+NexusApp is a single-process **WPF desktop app** that targets **.NET 10**
+(`net10.0-windows`). The build publishes NexusApp self-contained for `win-x64`.
 NexusApp uses the **MVVM** pattern with `CommunityToolkit.Mvvm`. A thin services
 layer sits under the UI.
 

--- a/NexusApp.Tests/NexusApp.Tests.csproj
+++ b/NexusApp.Tests/NexusApp.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>

--- a/NexusApp.Tests/NexusApp.Tests.csproj
+++ b/NexusApp.Tests/NexusApp.Tests.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NexusApp.Tests/SourceFiles.cs
+++ b/NexusApp.Tests/SourceFiles.cs
@@ -11,7 +11,7 @@ internal static class SourceFiles
 {
     public static string ReadAppSource(string relativePath)
     {
-        // bin/Debug/net8.0-windows.../ -> walk up to the directory that contains NexusApp/Views.
+        // bin/Debug/net10.0-windows.../ -> walk up to the directory that contains NexusApp/Views.
         var dir = new DirectoryInfo(System.AppContext.BaseDirectory);
         while (dir != null && !File.Exists(Path.Combine(dir.FullName, "NexusApp", "Views", "OverlayWindow.xaml.cs")))
             dir = dir.Parent;

--- a/NexusApp/NexusApp.csproj
+++ b/NexusApp/NexusApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>

--- a/NexusApp/NexusApp.csproj
+++ b/NexusApp/NexusApp.csproj
@@ -37,9 +37,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.4022.49" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.11" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.4078.44" />
   </ItemGroup>
 
   <!-- Let the test project reach internal seams (e.g. Logger.WriteTo). -->

--- a/NexusApp/Services/PortableUpdater.cs
+++ b/NexusApp/Services/PortableUpdater.cs
@@ -244,7 +244,7 @@ public sealed class PortableUpdater : IPortableSwapper
                 throw new InvalidOperationException($"refused archive entry \"{entry.FullName}\": {issue}");
             if (rel.Length == 0) continue;   // the top-level folder entry itself
             var target = Path.GetFullPath(Path.Combine(destRoot, rel));
-            // Defense in depth beside NormalizeEntry (and .NET 8's own refusal): nothing
+            // Defense in depth beside NormalizeEntry (and the runtime's own refusal): nothing
             // canonicalizing outside the destination is ever created.
             if (!target.StartsWith(destRoot, StringComparison.OrdinalIgnoreCase))
                 throw new InvalidOperationException($"refused archive entry \"{entry.FullName}\": escapes the destination");

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Every download and install asks first. You can always update by hand from the [R
 
 **Tech stack**
 
-- **C# / .NET 8** with **WPF** (Windows-only, self-contained `win-x64` build)
+- **C# / .NET 10** with **WPF** (Windows-only, self-contained `win-x64` build)
 - **CommunityToolkit.Mvvm** for MVVM
 - **Microsoft.Data.Sqlite** for local storage
 - **Windows.Media.Ocr** (native WinRT OCR engine) for the auto-scan feature

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.400",
+    "rollForward": "latestFeature"
+  }
+}

--- a/nexus_installer.iss
+++ b/nexus_installer.iss
@@ -42,6 +42,18 @@ Name: "desktopicon"; Description: "Create a &desktop shortcut"; GroupDescription
 ; shipped as Nexus_v4.*; on upgrade, remove those so the app folder is left with
 ; only the renamed NexusApp.* files (no stale Nexus_v4.exe to launch by mistake).
 Type: files; Name: "{app}\Nexus_v4.*"
+; The .NET 10 publish no longer bundles the WinForms/designer assemblies or the 8.0
+; debugger DAC. Inno only overwrites shipped files, so on upgrade from a .NET 8
+; install these stale runtime files must be removed explicitly.
+Type: files; Name: "{app}\System.Windows.Forms.dll"
+Type: files; Name: "{app}\System.Windows.Forms.Primitives.dll"
+Type: files; Name: "{app}\System.Windows.Forms.Design.dll"
+Type: files; Name: "{app}\System.Windows.Forms.Design.Editors.dll"
+Type: files; Name: "{app}\WindowsFormsIntegration.dll"
+Type: files; Name: "{app}\Microsoft.VisualBasic.Forms.dll"
+Type: files; Name: "{app}\System.Design.dll"
+Type: files; Name: "{app}\System.Drawing.Design.dll"
+Type: files; Name: "{app}\mscordaccore_amd64_amd64_8.0.*.dll"
 
 [Files]
 Source: "{#PublishDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs

--- a/nexus_installer.iss
+++ b/nexus_installer.iss
@@ -2,7 +2,7 @@
 #define ExeName    "NexusApp.exe"
 ; PublishDir can be overridden from the command line (CI passes /DPublishDir=publish_out).
 #ifndef PublishDir
-  #define PublishDir "NexusApp\bin\x64\Release\net8.0-windows10.0.17763.0\win-x64\publish"
+  #define PublishDir "NexusApp\bin\x64\Release\net10.0-windows10.0.17763.0\win-x64\publish"
 #endif
 ; Version is single-sourced: by default it's read from the built exe's file
 ; version (which comes from the csproj <Version>). CI can still override with a


### PR DESCRIPTION
Moves the app and the test project from .NET 8 to .NET 10 (LTS, supported to November 2028). .NET 8 support ends 2026-11-10.

Changes:
- TargetFramework net10.0-windows10.0.17763.0 in both projects
- global.json pins SDK 10.0.400; both workflows read the SDK version from it
- Packages: Microsoft.Data.Sqlite 10.0.11, CommunityToolkit.Mvvm 8.4.2, Microsoft.Web.WebView2 1.0.4078.44, Microsoft.NET.Test.Sdk 18.9.0, xunit 2.9.3, xunit.runner.visualstudio 3.1.5
- Installer: publish path updated, and upgrades now remove stale .NET 8 runtime files
- Docs updated (README, ARCHITECTURE)

Verification:
- Full test suite passes on .NET 10 (2885 tests, 0 failures)
- dotnet list package --vulnerable --include-transitive is clean for both projects; the package refresh removes the high severity advisory in transitive SQLitePCLRaw.lib.e_sqlite3 2.1.6 (GHSA-2m69-gcr7-jv3q)
- Publish layout diffed against a .NET 8 baseline: the portable layout is identical file for file; installer layout changes are the expected runtime differences
- Smoke tested from the published single-file build: UI, both WebView2 scenes, SQLite, OCR capture, update check