### PR TITLE
Fix the Operations modal layering and drop the duplicate location card

### DIFF
--- a/NexusApp.Tests/CommandPageModalTests.cs
+++ b/NexusApp.Tests/CommandPageModalTests.cs
@@ -1,0 +1,32 @@
+using Xunit;
+
+namespace NexusApp.Tests;
+
+// Source pins for the Operations page's modal layer. The system view's starmap is a native
+// WebView2 window, so no WPF modal can draw over it; every modal on the page must show and
+// hide through the helper pair that parks the map while the modal is up (the install-update
+// prompt rendered behind the starmap before this rule, 2026-08-20).
+public class CommandPageModalTests
+{
+    [Fact]
+    public void OnlyTheHelperPair_TouchesTheModalHostVisibility()
+    {
+        var src = SourceFiles.ReadAppSource(@"Views\CommandPage.cs");
+        // Exactly one show site (inside ShowModalHost) and one hide site (inside HideModalHost).
+        // A second occurrence of either means a modal bypassed the map-parking helpers.
+        Assert.Equal(1, System.Text.RegularExpressions.Regex.Matches(
+            src, @"_modalHost\.Visibility = Visibility\.Visible").Count);
+        Assert.Equal(1, System.Text.RegularExpressions.Regex.Matches(
+            src, @"_modalHost\.Visibility = Visibility\.Collapsed").Count);
+        Assert.Contains("HideMapForModal();", src);
+        Assert.Contains("RestoreMapAfterModal();", src);
+    }
+
+    [Fact]
+    public void ParkingTheMap_UsesHidden_SoTheLayoutHoleStays()
+    {
+        var src = SourceFiles.ReadAppSource(@"Views\CommandPage.SystemView.cs");
+        Assert.Contains("_mapView.Visibility = Visibility.Hidden", src);
+        Assert.Contains("_mapView.Visibility = Visibility.Visible", src);
+    }
+}

--- a/NexusApp/Views/CommandPage.SystemView.cs
+++ b/NexusApp/Views/CommandPage.SystemView.cs
@@ -861,6 +861,18 @@ public sealed partial class CommandPage
         _mapPostedFor = null;
     }
 
+    // Modal support: the WebView2 owns its rectangle, so the page's modal layer cannot draw
+    // over it. Hidden (not Collapsed) keeps the layout hole in place while a modal is up.
+    private void HideMapForModal()
+    {
+        if (_mapView is not null) _mapView.Visibility = Visibility.Hidden;
+    }
+
+    private void RestoreMapAfterModal()
+    {
+        if (_mapView is not null) _mapView.Visibility = Visibility.Visible;
+    }
+
     /// <summary>Sends the locator init: the player's system, the player marker, and every planner
     /// affordance off. Skipped when nothing about the location changed, because Refresh runs on
     /// every data tick and reinitializing the scene rebuilds its whole object graph.</summary>

--- a/NexusApp/Views/CommandPage.cs
+++ b/NexusApp/Views/CommandPage.cs
@@ -744,14 +744,29 @@ public sealed partial class CommandPage : UserControl
         panel.HorizontalAlignment = HorizontalAlignment.Center;
         panel.MouseLeftButtonDown += (_, e) => e.Handled = true;
         _modalHost.Children.Add(panel);
-        _modalHost.Visibility = Visibility.Visible;
+        ShowModalHost();
     }
 
     private void CloseInstallConfirm(bool cancelled)
     {
         if (cancelled) Logger.Info("[UI] install update: cancelled");
+        HideModalHost();
+    }
+
+    // The system view's starmap is a native WebView2 window, so no WPF modal can draw over it.
+    // Every modal on this page must show and hide through this pair, which parks the map for
+    // exactly as long as the modal is up.
+    private void ShowModalHost()
+    {
+        HideMapForModal();
+        _modalHost.Visibility = Visibility.Visible;
+    }
+
+    private void HideModalHost()
+    {
         _modalHost.Visibility = Visibility.Collapsed;
         _modalHost.Children.Clear();
+        RestoreMapAfterModal();
     }
 
     // Confirm already given: quiesce the UI (version-skew guard: nothing may lazily load
@@ -793,13 +808,12 @@ public sealed partial class CommandPage : UserControl
         panel.VerticalAlignment = VerticalAlignment.Center;
         panel.HorizontalAlignment = HorizontalAlignment.Center;
         _modalHost.Children.Add(panel);
-        _modalHost.Visibility = Visibility.Visible;
+        ShowModalHost();
     }
 
     private void CloseInstallingOverlay()
     {
-        _modalHost.Visibility = Visibility.Collapsed;
-        _modalHost.Children.Clear();
+        HideModalHost();
     }
 
     // Spec-mandated warning when a download or install-time hash check refused the file.

--- a/NexusApp/Web/map/index.html
+++ b/NexusApp/Web/map/index.html
@@ -153,7 +153,9 @@
 .lite{position:absolute; inset:0; pointer-events:none; padding:13px 15px;
       display:flex; flex-direction:column; justify-content:space-between; z-index:6}
 .liteTop,.liteBot{display:flex; align-items:flex-start; justify-content:space-between; gap:12px}
-.liteBot{align-items:flex-end}
+/* The bottom row holds only the full-starmap link since the location card left (2026-08-20):
+   the pilot card beside the map already names the place, so the scene stopped repeating it. */
+.liteBot{align-items:flex-end; justify-content:flex-end}
 .liteEyebrow{font:700 9px/1 'JetBrains Mono',monospace; letter-spacing:.16em; color:#7FE9E0}
 .liteHint{font:400 9px/1 'JetBrains Mono',monospace; letter-spacing:.08em; color:#8693A0;
           margin-top:5px; opacity:.75}
@@ -163,18 +165,6 @@
          cursor:pointer; border-radius:3px; backdrop-filter:blur(3px)}
 .liteBtn:hover{color:#FFB23E; border-color:rgba(255,178,62,.42)}
 .liteBtn.on{color:#FFB23E; border-color:rgba(255,178,62,.42); background:rgba(255,178,62,.10)}
-.liteYou{background:rgba(6,9,14,.86); border:1px solid rgba(127,233,224,.40);
-         padding:9px 13px 10px; backdrop-filter:blur(4px); max-width:280px}
-.liteYouHead{display:flex; align-items:center; gap:8px}
-.liteYouHead i{width:7px; height:7px; border-radius:50%; background:#7FE9E0; box-shadow:0 0 8px #7FE9E0}
-.liteYouHead span{font:700 9px/1 'JetBrains Mono',monospace; letter-spacing:.16em; color:#7FE9E0}
-/* Last-known state (2026-08-17): grey card, no glow, the head SAYS the reading is history. */
-.liteYou.stale{border-color:rgba(134,147,160,.45)}
-.liteYou.stale .liteYouHead i{background:#8693A0; box-shadow:none}
-.liteYou.stale .liteYouHead span{color:#8693A0}
-.liteYou.stale .liteYouName{color:#8693A0}
-.liteYouName{font:700 19px/1.1 'Rajdhani',sans-serif; color:#EAF1F6; margin-top:5px}
-.liteYouSub{font:400 11px/1.4 'Chakra Petch',sans-serif; color:#8693A0; margin-top:3px}
 .liteOpen{pointer-events:auto; font:700 9px/1 'JetBrains Mono',monospace; letter-spacing:.12em;
           padding:6px 11px; background:rgba(12,18,25,.82); color:#8693A0;
           border:1px solid rgba(127,233,224,.102); cursor:pointer; border-radius:3px}
@@ -207,11 +197,6 @@
       </div>
     </div>
     <div class="liteBot">
-      <div class="liteYou" id="liteYou">
-        <div class="liteYouHead"><i></i><span>YOU ARE HERE</span></div>
-        <div class="liteYouName" id="liteYouName">Unknown</div>
-        <div class="liteYouSub" id="liteYouSub">Nexus has not seen a location yet.</div>
-      </div>
       <button class="liteOpen" id="liteOpen">OPEN FULL STARMAP</button>
     </div>
   </div>
@@ -628,26 +613,11 @@ function setDrift(on){
   controls.autoRotateSpeed = 0.144;         /* half the old 0.288 (2026-08-17), a barely-there idle */
   document.getElementById('liteDrift').classList.toggle('on', !!on && !REDUCED);
 }
-/* Fills the locator card and wires its controls. Called on every init so a location change while
-   Operations is open repaints the card without rebuilding the scene. */
+/* Wires the locator chrome. The location card left on 2026-08-20 (the pilot card beside the map
+   already names the place); the scene's own player marker still carries the live/last-known
+   styling. Called on every init so a system change repaints the eyebrow without a rebuild. */
 function applyLite(msg){
   document.getElementById('liteSystem').textContent = (state.system||'').toUpperCase();
-  const o = (state.playerMarker!=null)? BY_ID.get(state.playerMarker) : null;
-  /* Three states, not two. The catalog resolves only some of the log's location tokens, so the app
-     often KNOWS where the player is by name while having no object to put a marker on. Falling
-     back to "unknown" in that middle state would contradict the line right underneath it, which
-     names the place. Named-but-unmarked reads at reduced opacity: known, but not placeable. */
-  const name = o ? o.name : (msg.playerName || null);
-  /* Liveness (2026-08-17): with the game closed the card goes grey and its head SAYS the reading
-     is history - YOU ARE HERE is a live claim and must not survive the session. */
-  const live = state.playerLive !== false;
-  document.getElementById('liteYou').classList.toggle('stale', !live && !!name);
-  document.querySelector('#liteYou .liteYouHead span').textContent =
-    live || !name ? 'YOU ARE HERE' : 'LAST KNOWN LOCATION';
-  document.getElementById('liteYouName').textContent = name || 'Location unknown';
-  document.getElementById('liteYouSub').textContent =
-    name ? (msg.playerNote || (state.system||'')) : 'Nexus has not seen a location yet.';
-  document.getElementById('liteYou').style.opacity = o ? '1' : (name ? '.86' : '.72');
   /* Homed ONCE, not on every init, and the same for the drift default. A location change re-sends
      the init, and snapping the camera home or restarting a drift the user switched off would be the
      app fighting the user. */


### PR DESCRIPTION
Two Operations tab fixes.

Update prompt behind the starmap: the system view starmap is a native WebView2 window, so the page's WPF modal layer composed underneath it and the install-update prompt appeared behind the map. Every modal on the page now shows and hides through one helper pair that hides the map for exactly as long as the modal is up and restores it on close. Source-pin tests make bypassing the helpers a test failure.

Location card removed from the Operations starmap: the in-scene YOU ARE HERE / LAST KNOWN LOCATION card duplicated the pilot card beside the map, so it is gone (markup, styles, and fill code). The full-starmap button keeps its corner, and the scene's own player marker with its live and last-known styling is unchanged.

Verification: full suite 2897 tests, 0 failures; launched and confirmed the Operations scene initializes cleanly without the card.